### PR TITLE
Close sockets when server is down

### DIFF
--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -142,6 +142,10 @@ class PushyClient
     Chef::Log.error("[#{node_name}] #{message}: #{exception}\n#{exception.backtrace.join("\n")}")
   end
 
+  def on_server_availability_change(&block)
+    @heartbeater.on_server_availability_change(&block)
+  end
+
   def online?
     @heartbeater.online?
   end

--- a/lib/pushy_client/heartbeater.rb
+++ b/lib/pushy_client/heartbeater.rb
@@ -4,6 +4,7 @@ class PushyClient
       @client = client
       @online_mutex = Mutex.new
       @heartbeat_sequence = 1
+      @on_server_availability_change = []
     end
 
     attr_reader :client
@@ -20,6 +21,10 @@ class PushyClient
       @online
     end
 
+    def on_server_availability_change(&block)
+      @on_server_availability_change << block
+    end
+
     def start
       @incarnation_id = nil
       @online_threshold = client.config['push_jobs']['heartbeat']['online_threshold']
@@ -28,7 +33,7 @@ class PushyClient
 
       @online_counter = 0
       @offline_counter = 0
-      @online = true
+      set_online(true)
 
       @heartbeat_thread = Thread.new do
         Chef::Log.info "[#{node_name}] Starting heartbeat / offline detection thread ..."
@@ -40,7 +45,7 @@ class PushyClient
               if @online
                 if @offline_counter > offline_threshold
                   Chef::Log.info "[#{node_name}] Server has missed #{@offline_counter} heartbeats in a row.  Considering it offline, and stopping heartbeat."
-                  @online = false
+                  set_online(false)
                   @online_counter = 0
                 else
                   @offline_counter += 1
@@ -91,10 +96,19 @@ class PushyClient
 
         if !@online && @online_counter > online_threshold
           Chef::Log.info "[#{node_name}] Server has heartbeated #{@online_counter} times without missing more than #{offline_threshold} heartbeats in a row.  Considering it online, and starting to heartbeat ..."
-          @online = true
+          set_online(true)
         else
           @online_counter += 1
         end
+      end
+    end
+
+    private
+
+    def set_online(online)
+      @online = online
+      @on_server_availability_change.each do |block|
+        block.call(online)
       end
     end
   end


### PR DESCRIPTION
to ensure that stray packets don't get dumped on
the server when it comes back up.
Also fixes some zeromq errors that happen when you
try to close a socket that is open for ZMQ.select.
