### PR TITLE
Remove mixlib cli dependency that is no longer needed

### DIFF
--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = '0.0.1'
 
-  gem.add_dependency "mixlib-cli", "~> 1.2.2"
   gem.add_dependency "mixlib-log", "~> 1.3.0"
   gem.add_dependency "chef", ">= 0.10.12"
   gem.add_dependency "zmq"


### PR DESCRIPTION
Pushy uses the chef gem for cli functionality, so no need for this dependency any longer, which is also conflicting with the chef-gem's mixlib cli version and causing build breaks for pushy.
