### PR TITLE
Make config_fetcher fix back compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Chef Push Client Changes
+
+## 1.0.1 - 2014-04-09
+
+* Add require with rescue for chef/config_fetcher needed for compatibility with
+  Chef >= 11.8.0.
+
+* Add signal handling for the client. The client now does a graceful
+  shutdown when it receives a `TERM`, `QUIT`, or `KILL` signal. The
+  client will reconfigure itself if sent `USR1`. This improves the
+  compatibility of the push client to be managed under runit which
+  sends signals for restart.
+
+* Add Apache 2 license and headers in preparation for open sourcing.
+
+* Unify gem and repo tag versioning scheme.
+

--- a/lib/pushy_client/cli.rb
+++ b/lib/pushy_client/cli.rb
@@ -17,7 +17,9 @@
 
 require 'chef/application'
 require 'chef/config'
-require 'chef/config_fetcher'
+# This is needed for compat with chef-client >= 11.8.0.
+# To keep compat with older chef-client, rescue if not found
+require 'chef/config_fetcher' rescue 'assuming chef-client < 11.8.0'
 require 'chef/log'
 require 'pushy_client'
 require 'pushy_client/version'

--- a/lib/pushy_client/version.rb
+++ b/lib/pushy_client/version.rb
@@ -16,5 +16,5 @@
 #
 
 class PushyClient
-  VERSION = "0.0.2"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
- Bump gem version to 1.0.1 to match what will be the next repo tag
- Add a CHANGELOG
- Rescue the require of chef/config_fetcher so that the code remains
  usable with versions of chef < 11.8.0.
