### PR TITLE
Adjust plugin loading for ohai 7

### DIFF
--- a/lib/pushy_client/cli.rb
+++ b/lib/pushy_client/cli.rb
@@ -100,8 +100,7 @@ class PushyClient
       end
 
       ohai = Ohai::System.new
-      ohai.require_plugin('os')
-      ohai.require_plugin('hostname')
+      ohai.all_plugins('hostname')
 
       @client = PushyClient.new(
         :chef_server_url => Chef::Config[:chef_server_url],

--- a/lib/pushy_client/version.rb
+++ b/lib/pushy_client/version.rb
@@ -16,5 +16,5 @@
 #
 
 class PushyClient
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PushyClient::VERSION
 
-  gem.add_dependency "chef", ">= 0.10.12"
+  gem.add_dependency "chef", ">= 11.12.2"
   gem.add_dependency "zmq"
   gem.add_dependency "uuidtools"
 


### PR DESCRIPTION
Now requires chef-client >= 11.12.2

supersedes: https://github.com/opscode/opscode-pushy-client/pull/43
