### PR TITLE
Fixed missing load_plugins before require_plugin

### DIFF
--- a/lib/pushy_client/windows_service.rb
+++ b/lib/pushy_client/windows_service.rb
@@ -58,7 +58,7 @@ class PushyClient
 
           # Lifted from PushyClient::CLI
           ohai = Ohai::System.new
-          ohai.load_plugins
+          ohai.all_plugins('os', 'hostname')
           ohai.require_plugin('os')
           ohai.require_plugin('hostname')
 

--- a/lib/pushy_client/windows_service.rb
+++ b/lib/pushy_client/windows_service.rb
@@ -59,9 +59,7 @@ class PushyClient
           # Lifted from PushyClient::CLI
           ohai = Ohai::System.new
           ohai.all_plugins('os', 'hostname')
-          ohai.require_plugin('os')
-          ohai.require_plugin('hostname')
-
+  
           @client = PushyClient.new(
                                     :chef_server_url => Chef::Config[:chef_server_url],
                                     :client_key      => Chef::Config[:client_key],

--- a/lib/pushy_client/windows_service.rb
+++ b/lib/pushy_client/windows_service.rb
@@ -58,6 +58,7 @@ class PushyClient
 
           # Lifted from PushyClient::CLI
           ohai = Ohai::System.new
+          ohai.load_plugins
           ohai.require_plugin('os')
           ohai.require_plugin('hostname')
 

--- a/lib/pushy_client/windows_service.rb
+++ b/lib/pushy_client/windows_service.rb
@@ -58,8 +58,8 @@ class PushyClient
 
           # Lifted from PushyClient::CLI
           ohai = Ohai::System.new
-          ohai.all_plugins('os', 'hostname')
-  
+          ohai.all_plugins('os')
+          ohai.all_plugins('hostname')
           @client = PushyClient.new(
                                     :chef_server_url => Chef::Config[:chef_server_url],
                                     :client_key      => Chef::Config[:client_key],


### PR DESCRIPTION
The lack of load_plugins was causing the windows service to fail:

[2014-07-03T15:51:55-04:00] INFO: Pushy Client Service initialized
[2014-07-03T15:52:01-04:00] INFO: Pushy version: 1.1.1
[2014-07-03T15:52:01-04:00] ERROR: Ohai::Exceptions::DependencyNotFound: Can not find a plugin for dependency os
[2014-07-03T15:52:01-04:00] ERROR: Terminating pushy-client service...