### PR TITLE
Fix for periodic reconfigure causing early termination

### DIFF
--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -114,6 +114,13 @@ class PushyClient
   end
 
   def reconfigure
+    first = true
+    while !@job_runner.safe_to_reconfigure? do
+      Chef::Log.info "[#{node_name}] Job in flight, delaying reconfigure" if first
+      first = false
+      sleep 5
+    end
+
     @reconfigure_lock.synchronize do
       Chef::Log.info "[#{node_name}] Reconfiguring client / reloading keys ..."
 
@@ -148,7 +155,6 @@ class PushyClient
     after_stat = GC.stat()
     stat = :count
     delta = after_stat[stat] - before_stat[stat]
-    pp after_stat: after_stat, stat: stat, delta: delta 
     Chef::Log.info("[#{node_name}] Forced GC; Stat #{stat} changed #{delta}")
   end
 

--- a/lib/pushy_client/job_runner.rb
+++ b/lib/pushy_client/job_runner.rb
@@ -44,6 +44,12 @@ class PushyClient
     attr_reader :command
     attr_reader :lockfile
 
+    def safe_to_reconfigure?
+      @state_lock.synchronize do
+        @state == :idle
+      end
+    end
+
     def node_name
       client.node_name
     end
@@ -299,7 +305,7 @@ class PushyClient
         when "base64"
           f.write(Base64.decode64(filedata))
         else
-          Chef::Log.error("[#{node_name}] Received commit #{job_id}, but file starting with '#{file.slice(0,80)}' has a bad format!") 
+          Chef::Log.error("[#{node_name}] Received commit #{job_id}, but file starting with '#{file.slice(0,80)}' has a bad format!")
         end
       end
       path


### PR DESCRIPTION
The periodic reconfigurer can cause running jobs to terminate early; this should mitigate but not outright fix the issue.

This is a minimal change fix that delays reconfiguration until any running jobs have terminated. However this does have some race conditions, in that
1) The reconfigure is delayed by polling on idle; however we don't block the acceptance of a new job immediately after reconfiguration, and that job may be terminated
2) A new job may be started before the poller recognizes that the old job 

Fixes #69 