### PR TITLE
Ma/no reconfigure backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Chef Push Client Changes
 
+## 1.3.4
+* Add wait so that periodic reconfiguration doesn't kill running jobs
+
+## 1.3.3
+* Fixes to windows service to include multiple config files
+* Search for config files in multiple places
+* Check if DNS resolution works and log if not
+* Logging enhancements
+
 ## 1.3.1
 
 * Bump version to avoid semver issues with non-compliant 1.3.0.rc.0 tag

--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -93,6 +93,13 @@ class PushyClient
   end
 
   def reconfigure
+    first = true
+    while !@job_runner.safe_to_reconfigure? do
+      Chef::Log.info "[#{node_name}] Job in flight, delaying reconfigure" if first
+      first = false
+      sleep 5
+    end
+
     @reconfigure_lock.synchronize do
       Chef::Log.info "[#{node_name}] Reconfiguring client / reloading keys ..."
 

--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -1,6 +1,7 @@
 #
-# Author:: John Keiser (<jkeiser@opscode.com>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Author:: John Keiser (<jkeiser@chef.io>)
+# Author:: John Keiser (<mark@chef.io>)
+# Copyright:: Copyright (c) 2012-5 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/pushy_client/job_runner.rb
+++ b/lib/pushy_client/job_runner.rb
@@ -43,6 +43,12 @@ class PushyClient
     attr_reader :command
     attr_reader :lockfile
 
+    def safe_to_reconfigure?
+      @state_lock.synchronize do
+        @state == :idle
+      end
+    end
+
     def node_name
       client.node_name
     end

--- a/lib/pushy_client/version.rb
+++ b/lib/pushy_client/version.rb
@@ -1,4 +1,4 @@
-# @copyright Copyright 2014 Chef Software, Inc. All Rights Reserved.
+# @copyright Copyright 2014-15 Chef Software, Inc. All Rights Reserved.
 #
 # This file is provided to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file
@@ -16,5 +16,5 @@
 #
 
 class PushyClient
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end


### PR DESCRIPTION
The periodic reconfigurer can cause running jobs to terminate early; this should mitigate but not outright fix the issue.

This is a minimal change fix that delays reconfiguration until any running jobs have terminated. However this does have some race conditions, in that
1) The reconfigure is delayed by polling on idle; however we don't block the acceptance of a new job immediately after reconfiguration, and that job may be terminated
2) A new job may be started before the poller recognizes that the old job

Backport of #71