### PR TITLE
Allow recent omnibus-software ruby version convention.

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 56f4933c94cfcb85be7b3564ccab280769d90d12
+  revision: 45fc26cf6b4692860bd44dc154c690e1e9265870
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: d66b7fcafd5f8fb55e974913999fd1b9db564f1e
+  revision: 884a22a0d25edb9193947e411a0a9a4047e662d4
   specs:
     omnibus (5.0.0)
       aws-sdk (~> 2)

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -38,15 +38,12 @@ end
 override :bundler,        version: "1.7.12"
 # Uncomment to pin the chef version
 #override :chef,           version: "12.2.1"
-override :ruby,           version: "2.1.6"
-######
-# Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working
-# https://bugs.ruby-lang.org/issues/11033
-# Going to leave 2.1.5 for now since there is a workaround
-override :'ruby-windows', version: "2.1.5"
-override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
-#override :'ruby-windows', version: "2.0.0-p451"
-######
+if windows?
+  override :'ruby-windows', version: "2.1.5"
+  override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+else
+  override :ruby,           version: "2.1.6"
+end
 
 # Short term fix to keep from breaking old client build process
 override :libzmq, version: "4.0.5"


### PR DESCRIPTION
This allows master to build at chef/omnibus-software#556