### PR TITLE
push_client.rb: uninitialized constant Chef::REST

### DIFF
--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -206,7 +206,10 @@ class PushyClient
   private
 
   def rest
-    @rest ||= Chef::REST.new(chef_server_url, client_name, client_key)
+    @rest ||= begin
+      require 'chef/rest'
+      Chef::REST.new(chef_server_url, client_name, client_key)
+    end
   end
 
   def get_config


### PR DESCRIPTION
Seems there was no import of `chef/rest` to make use of `Chef::REST`

Client runtime error before:
```
2016-02-28_04:53:13.29198 INFO: [<HOST>] Starting client ...
2016-02-28_04:53:13.29203 INFO: [<HOST>] Retrieving configuration from https://<HOST>.<DOMAIN>.<TLD>/organizations/<ORG>//pushy/config/<HOST>: ...
2016-02-28_04:53:13.29214 /opt/push-jobs-client/embedded/lib/ruby/gems/2.1.0/gems/opscode-pushy-client-2.0.2/lib/pushy_client.rb:209:in `rest': uninitialized constant Chef::REST (NameError)
2016-02-28_04:53:13.29216   from /opt/push-jobs-client/embedded/lib/ruby/gems/2.1.0/gems/opscode-pushy-client-2.0.2/lib/pushy_client.rb:220:in `get_config'
2016-02-28_04:53:13.29217   from /opt/push-jobs-client/embedded/lib/ruby/gems/2.1.0/gems/opscode-pushy-client-2.0.2/lib/pushy_client.rb:94:in `start'
2016-02-28_04:53:13.29217   from /opt/push-jobs-client/embedded/lib/ruby/gems/2.1.0/gems/opscode-pushy-client-2.0.2/lib/pushy_client/cli.rb:138:in `run_application'
2016-02-28_04:53:13.29218   from /opt/push-jobs-client/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.0/lib/chef/application.rb:58:in `run'
2016-02-28_04:53:13.29218   from /opt/push-jobs-client/embedded/lib/ruby/gems/2.1.0/gems/opscode-pushy-client-2.0.2/bin/pushy-client:8:in `<top (required)>'
2016-02-28_04:53:13.29218   from /opt/push-jobs-client/bin/pushy-client:53:in `load'
2016-02-28_04:53:13.29219   from /opt/push-jobs-client/bin/pushy-client:53:in `<main>'
```