### PR TITLE
Don't buffer more than a few heartbeats

### DIFF
--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -145,6 +145,8 @@ class PushyClient
       # Note setting this to '1' causes the client to crash on send, but perhaps that
       # beats storming the server when the server restarts
       @command_socket.setsockopt(ZMQ::RCVHWM, 0)
+      # Buffering more than a few heartbeats can cause trauma on the server after restart
+      @command_socket.setsockopt(ZMQ::SNDHWM, 3)
 
       if client.using_curve
         @command_socket.setsockopt(ZMQ::CURVE_SERVERKEY, server_curve_pub_key)


### PR DESCRIPTION
Buffering heartbeats can cause trauma on the server after restart.

Related to these PRs:
https://github.com/chef/omnibus-pushy/pull/92
https://github.com/chef/oc-pushy-pedant/pull/54

https://github.com/chef/opscode-pushy-client/pull/84