### PR TITLE
Fix Reconfigure Loops for 2.x clients using 1.x connection protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Chef Push Client Changes
 
+## 2.1.1
+
+* Do not enforce 2.x reconfigure protocol on clients that have fallen back to 1.x protocols
+
 ## 2.1.0
 
 * Limited the zeromq high water mark to prevent buffering of heartbeats, which cause packet floods when the push-jobs-server restarts
@@ -28,7 +32,7 @@
 
 * Bump version to avoid semver issues with non-compliant 1.3.0.rc.0 tag
 
-## 1.3.0 
+## 1.3.0
 
 * Move to ZeroMQ 4 and ffi-rzmq.
 * Update Chef to 12.0

--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -75,6 +75,7 @@ class PushyClient
   attr_accessor :hostname
   attr_accessor :whitelist
   attr_reader :incarnation_id
+  attr_reader :legacy_mode # indicate we've fallen back to 1.x
 
   # crypto
   attr_reader :client_curve_pub_key
@@ -222,8 +223,10 @@ class PushyClient
     if config.has_key?("curve_public_key")
     # Version 2.0  or greater, we should use encryption
       @using_curve = true
+      @legacy_mode = false
     elsif allow_unencrypted then
       @using_curve = false
+      @legacy_mode = true
       Chef::Log.info "[#{node_name}] No key returned from server; falling back to 1.x protocol (no encryption)"
     else
       msg = "[#{node_name}] Exiting: No key returned from server; server may be using 1.x protocol. The config flag 'allow_unencrypted' disables encryption and allows use of 1.x server. Use with caution!"

--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -287,7 +287,7 @@ class PushyClient
               end
             end
 
-            if !received_command
+            if !received_command && !@client.legacy_mode
               seconds_since_connection += 1
               if (seconds_since_connection > 3 )
                 Chef::Log.error "[#{node_name}] No messages being received on command port in #{seconds_since_connection}s.  Possible encryption problem?"

--- a/lib/pushy_client/version.rb
+++ b/lib/pushy_client/version.rb
@@ -18,6 +18,6 @@
 # Note: the version must also be updated in
 # omnibus/config/projects/push-jobs-client.rb
 class PushyClient
-  VERSION = "2.0.2"
+  VERSION = "2.1.1"
   PROTOCOL_VERSION = "2.0"
 end

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -27,7 +27,7 @@ replace  "opscode-push-jobs-client"
 conflict "opscode-push-jobs-client"
 
 build_iteration 1
-build_version "2.1.0"
+build_version "2.1.1"
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"


### PR DESCRIPTION
Do not enforce 2.x reconfigure protocol on clients that have fallen back to 1.x

Fixes #94 & SPOOL-306