### PR TITLE
Change sigkill handler to sigint

### DIFF
--- a/lib/pushy_client/cli.rb
+++ b/lib/pushy_client/cli.rb
@@ -140,9 +140,9 @@ class PushyClient
       # install signal handlers
       # Windows does not support QUIT and USR1 signals
       exit_signals = if Chef::Platform.windows?
-                       ["TERM", "KILL"]
+                       ["TERM", "INT"]
                      else
-                       ["TERM", "QUIT", "KILL"]
+                       ["TERM", "QUIT", "INT"]
                      end
 
       exit_signals.each do |sig|


### PR DESCRIPTION
You can't trap SIGKILL (kill -9), but previously it was ignored, now it gives
an EINVAL error preventing push jobs client from starting.