### PR TITLE
Address exponential thread increases

### DIFF
--- a/.chef/client.rb
+++ b/.chef/client.rb
@@ -1,0 +1,11 @@
+current_dir = File.expand_path(File.dirname(__FILE__))
+
+chef_server_url "https://api.chef-server.dev/organizations/push-client-local"
+log_location STDOUT
+ssl_verify_mode :verify_none
+
+node_name "push-client-dev-local"
+client_key "#{current_dir}/push-client-dev-local.pem"
+
+validation_client_name "push-client-local-validator"
+validation_key "#{ENV['INSTALLER_PATH'] || "#{ENV['HOME']}/Downloads"}/push-client-local-validator.pem"

--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,0 +1,11 @@
+current_dir = File.expand_path(File.dirname(__FILE__))
+
+chef_server_url "https://api.chef-server.dev/organizations/push-client-local"
+log_location STDOUT
+ssl_verify_mode :verify_none
+
+node_name "local-dev"
+client_key "#{ENV['INSTALLER_PATH'] || "#{ENV['HOME']}/Downloads"}/local-dev.pem"
+
+validation_client_name "push-client-local-validator"
+validation_key "#{ENV['INSTALLER_PATH'] || "#{ENV['HOME']}/Downloads"}/push-client-local-validator.pem"

--- a/.chef/push-jobs-client.rb
+++ b/.chef/push-jobs-client.rb
@@ -1,0 +1,13 @@
+current_dir = File.expand_path(File.dirname(__FILE__))
+
+chef_server_url "https://api.chef-server.dev/organizations/push-client-local"
+log_location STDOUT
+ssl_verify_mode :verify_none
+
+node_name "push-client-dev-local"
+client_key "#{current_dir}/push-client-dev-local.pem"
+
+trusted_certs_dir "#{current_dir}/trusted_certs"
+whitelist {
+
+}

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Description
+
+Briefly describe the issue
+
+# Push Jobs Client Version
+
+Tell us which version of the Push Jobs Client you are running. Run `gem list opscode-pushy-client` to display the version.
+
+# Platform Version
+
+Tell us which operating system distribution and version Push Jobs Client is running on.
+
+# Replication Case
+
+Tell us what steps to take to replicate your problem. See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) for information on how to create a good replication case.
+
+# Stacktrace
+
+Please include the stacktrace.out output or link to a gist of it, if there is one.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description
+
+[Please describe what this change achieves]
+
+### Issues Resolved
+
+[List any existing issues this PR resolves, or any Discourse or
+StackOverflow discussion that's relevant]
+
+### Check List
+
+- [ ] New functionality includes tests
+- [ ] All tests pass
+- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
+- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 test.xml
 vendor
+.chef/push-client-dev-local.pem

--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
+# Push Jobs Client
 
-# Setup
+Want to find out more about Push Jobs? Check out [docs.chef.io](https://docs.chef.io/push_jobs.html)!
+
+## Development
+### Setup Local Machine
 
     bundle install
     brew install zeromq
 
-# To run: bin/pushy-client -v -n DERPY -s http://33.33.33.10:10003
+### Setup Chef Server w/ Push Jobs Server
+1. Check out chef/chef-server and start DVM w/ Manage and Push Jobs.
+```yaml
+# config.yml
+vm:
+  plugins:
+    chef-manage: true
+    push-jobs-server: true
+```
+Run `vagrant up` to bring up the Push Jobs Server.
 
+2. Register you local machine as a node on the chef-server. From `chef-server/dev`, run:
+```shell
+vagrant ssh
+sudo chef-server-ctl user-create local-dev Local Dev local@chef.io 'password' -f /installers/local-dev.pem
+sudo chef-server-ctl org-create push-client-local "Local Push Client Development" -a local-dev -f /installers/push-client-local-validator.pem
+```
 
-# License
+3. Add your local machine as a node on the Chef Server.
+```shell
+chef-client -c .chef/client.rb
+```
 
-Pushy - The push jobs component for chef
+### Start Push Jobs Client
+```shell
+./bin/pushy-client -c .chef/push-jobs-client.rb
+```
 
-|                      |                                          |
-|:---------------------|:-----------------------------------------|
-| **Copyright:**       | Copyright (c) 2008-2014 Chef Software, Inc.
-| **License:**         | Apache License, Version 2.0
+## Contributing
 
-All files in the repository are licensed under the Apache 2.0 license. If any
-file is missing the License header it should assume the following is attached;
-
-Copyright 2014 Chef Software Inc
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+For information on contributing to this project see <https://github.com/chef/chef/blob/master/CONTRIBUTING.md>

--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -292,6 +292,7 @@ class PushyClient
               if (seconds_since_connection > 3 )
                 Chef::Log.error "[#{node_name}] No messages being received on command port in #{seconds_since_connection}s.  Possible encryption problem?"
                 client.trigger_reconfigure
+                break
               end
             end
 

--- a/lib/pushy_client/version.rb
+++ b/lib/pushy_client/version.rb
@@ -18,6 +18,6 @@
 # Note: the version must also be updated in
 # omnibus/config/projects/push-jobs-client.rb
 class PushyClient
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
   PROTOCOL_VERSION = "2.0"
 end


### PR DESCRIPTION
In cases where the Push Jobs Client loses connectivity to the Push Jobs Server, it can enter into a reconfigure loop causing an exponential increase in threads ultimately leading to the server falling over because Ruby has consumed all the resources. By breaking out of the protocol handler loop after triggering the reconfigure, the thread count now grows linearly (one thread per reconfigure) instead of exponentially. Completely avoiding the thread growth entirely would require more a more complex and time consuming rewrite.