### PR TITLE
Fix ohai gem constraints

### DIFF
--- a/omnibus/acceptance/.chef/knife.rb
+++ b/omnibus/acceptance/.chef/knife.rb
@@ -1,0 +1,10 @@
+current_dir = File.dirname(__FILE__)
+log_location             STDOUT
+node_name                "acceptance"
+client_key               "#{current_dir}/acceptance.pem"
+validation_client_name   "example_validator"
+validation_key           "#{current_dir}/example_validator.pem"
+chef_server_url          "https://192.168.33.30/organizations/example"
+cache_type               'BasicFile'
+cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
+ssl_verify_mode          :verify_none

--- a/omnibus/acceptance/.kitchen.yml
+++ b/omnibus/acceptance/.kitchen.yml
@@ -1,0 +1,64 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  chef_zero_port: 9010
+  chef_client:
+    config:
+      log_level: ":debug"
+
+platforms:
+  - name: ubuntu-14.04
+    run_list:
+      - recipe[apt::default]
+  - name: windows-2012r2
+    driver:
+      box: chef/windows-server-2012r2-standard # private
+    attributes:
+      push_jobs:
+        package_version: "2.1.3"
+        package_url: "https://packages.chef.io/stable/windows/2008r2/push-jobs-client-2.1.3-1-x86.msi"
+        package_checksum: "68f3c656ae8d4c8e36c5556069176753c7d143b4d410efc9deccbebc8a494976"
+
+suites:
+  - name: chef-server
+    excludes:
+      - windows-2012r2
+    run_list:
+      - recipe[chef-server]
+      - recipe[push_jobs_acceptance::chef-server-user-org]
+    attributes:
+      chef-server:
+        api_fqdn: 192.168.33.30
+        addons:
+          - push-jobs-server
+        accept_license: true
+    driver:
+      network:
+        - ['private_network', {ip: '192.168.33.30'}]
+      customize:
+        memory: 2048
+        cpus: 2
+      synced_folders:
+        - [".", "/tmp/acceptance"]
+
+  - name: push-jobs-client
+    run_list:
+      - recipe[push-jobs]
+    attributes:
+      push_jobs:
+        chef:
+          chef_server_url: https://192.168.33.30/organizations/example
+          node_name: 'push-client'
+          client_key_path: "c:\\tmp\\acceptance\\.chef\\push-client.pem"
+          ssl_verify_mode: 'verify_none'
+    driver:
+      network:
+        - ['private_network', {ip: '192.168.33.31'}]
+      customize:
+        memory: 2048
+        cpus: 2
+      synced_folders:
+        - [".", "/tmp/acceptance"]

--- a/omnibus/acceptance/Berksfile
+++ b/omnibus/acceptance/Berksfile
@@ -1,0 +1,6 @@
+source 'https://supermarket.chef.io'
+
+metadata
+
+cookbook 'apt'
+cookbook 'chef-server-ctl', git: 'https://github.com/stephenlauck/chef-server-ctl.git'

--- a/omnibus/acceptance/Berksfile.lock
+++ b/omnibus/acceptance/Berksfile.lock
@@ -1,0 +1,35 @@
+DEPENDENCIES
+  apt
+  chef-server-ctl
+    git: https://github.com/stephenlauck/chef-server-ctl.git
+    revision: 55bfa054f9d5cda86f1a96b28b5ccaddbec7a69d
+  push_jobs_acceptance
+    path: .
+    metadata: true
+
+GRAPH
+  apt (5.0.0)
+    compat_resource (>= 12.14.7)
+  chef-ingredient (0.21.2)
+    compat_resource (>= 12.10)
+  chef-server (5.1.0)
+    chef-ingredient (>= 0.18.0)
+  chef-server-ctl (0.1.0)
+    chef-server (>= 0.0.0)
+  compat_resource (12.16.2)
+  hostsfile (2.4.5)
+  packagecloud (0.2.5)
+  push-jobs (3.2.2)
+    chef-ingredient (>= 0.19.0)
+    compat_resource (>= 12.14.6)
+    runit (>= 1.2.0)
+  push_jobs_acceptance (0.1.0)
+    chef-server (>= 0.0.0)
+    chef-server-ctl (>= 0.0.0)
+    hostsfile (>= 0.0.0)
+    push-jobs (>= 0.0.0)
+  runit (3.0.0)
+    packagecloud (>= 0.0.0)
+    yum-epel (>= 0.0.0)
+  yum-epel (2.0.0)
+    compat_resource (>= 12.14.6)

--- a/omnibus/acceptance/Makefile
+++ b/omnibus/acceptance/Makefile
@@ -1,0 +1,13 @@
+
+chef-server:
+	kitchen converge chef-server-ubuntu-1404
+
+windows-client:
+	kitchen converge push-jobs-client-windows-2012r2
+
+ubuntu-client:
+	kitchen converge push-jobs-client-ubuntu-1404
+
+clean:
+  kitchen destroy
+	find .chef/$* ! -name 'knife.rb' -type f -exec rm -f {} +

--- a/omnibus/acceptance/README.md
+++ b/omnibus/acceptance/README.md
@@ -1,0 +1,29 @@
+# Push Client Omnibus Local Acceptance Environment
+
+This environment should be use for acceptance testing on Push Jobs Client
+omnibus packages. It's primary purpose is to give you a quick testing
+environment that may or may not fit all your needs.
+
+## Getting Started
+
+First, build your Chef Server.
+
+    make chef-server
+
+Then, build the client of your choice, either Ubuntu OR Windows.
+
+    make ubuntu-client
+    make windows-client
+
+## Using the Windows VM
+
+The default Windows VM listed in the `.kitchen.yml` file is a private image
+available to Chef employees. This is done because of licensing. If you want to
+use your own Windows image, you can override it using a `.kitchen.local.yml`
+or by temporarily over-writing the value in `.kitchen.yml`.
+
+## Cleanup
+
+To destroy the VM and cleanup all the associated artifacts, run the following:
+
+    make clean

--- a/omnibus/acceptance/metadata.rb
+++ b/omnibus/acceptance/metadata.rb
@@ -1,0 +1,12 @@
+name 'push_jobs_acceptance'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+description 'Installs/Configures push-jobs-acceptance'
+long_description 'Installs/Configures push-jobs-acceptance'
+version '0.1.0'
+
+depends 'chef-server'
+depends 'chef-server-ctl'
+depends 'push-jobs'
+depends 'hostsfile'

--- a/omnibus/acceptance/recipes/chef-server-user-org.rb
+++ b/omnibus/acceptance/recipes/chef-server-user-org.rb
@@ -1,0 +1,31 @@
+chef_server_user 'acceptance' do
+  firstname 'Example'
+  lastname 'User'
+  email 'acceptance@push-jobs.test'
+  password 'password'
+  private_key_path '/tmp/acceptance/.chef/acceptance.pem'
+  action :create
+end
+
+chef_server_org 'example' do
+  org_long_name 'Example Organization'
+  org_private_key_path '/tmp/acceptance/.chef/example.pem'
+  action :create
+end
+
+chef_server_org 'example' do
+  admins %w( acceptance )
+  action :add_admin
+end
+
+execute "knife ssl fetch https://192.168.33.30"
+
+execute "create-client" do
+  command "knife client create push-client --disable-editing -c /tmp/acceptance/.chef/knife.rb > /tmp/acceptance/.chef/push-client.pem"
+  not_if "knife client list | grep push-client"
+end
+#
+# execute "create-node" do
+#   command "knife node create push-client -c /tmp/acceptance/.chef/knife.rb"
+#   action :nothing
+# end

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -38,8 +38,10 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
+# Chef has a loose constraint on Ohai (< 9 for the gem, master for Omnibus),
+# so we can't pin to a specific version otherwise both versions will get
+# installed. Once Ohai hits 9.0, we need to update to a more modern Chef.
 override :chef,           version: "12.8.1"
-override :ohai,           version: "v8.19.0"
 
 override :bundler,        version: "1.11.2"
 override :rubygems,       version: "2.5.2"

--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = PushyClient::VERSION
 
   gem.add_dependency "chef", "12.8.1"
-  gem.add_dependency "ohai", "8.19.0"
+  gem.add_dependency "ohai", ">= 8.6.0.alpha.1", "< 9" # This constraint matches the one in chef@12.8.1
   gem.add_dependency "ffi-rzmq"
   gem.add_dependency "uuidtools"
 


### PR DESCRIPTION
### Description

Chef 12.8.1 has a loose gem constraint, which will cause two versions of
ohai to be installed. This results in push-jobs throwing an error if a
newer version of Ohai than the one push-jobs uses is ever installed.

Until we upgrade Chef to a more modern version, have the gem use the
same constraints as the chef gem, and do not override the omnibus
version of the gem installed.

### Issues Resolved

* #109 
* Chef COOL-614

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] CHANGELOG.md has been updated
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>