### PR TITLE
Pin ohai to 8.23.0 as chef/ohai master is now 13

### DIFF
--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -42,6 +42,7 @@ end
 # so we can't pin to a specific version otherwise both versions will get
 # installed. Once Ohai hits 9.0, we need to update to a more modern Chef.
 override :chef,           version: "12.8.1"
+override :ohai,           version: "v8.23.0" # pin to tag as master is now Ohai 13
 
 override :bundler,        version: "1.11.2"
 override :rubygems,       version: "2.5.2"


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

Pin Push Client to latest Ohai 8.x (now that Ohai is v13 on master).

### Issues Resolved

* Broken Jenkins Builds

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] CHANGELOG.md has been updated
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
