### PR TITLE
Update to modern dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ bin
 .bundle
 .config
 .yardoc
-/Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2
+  - 2.2.6
+  - 2.3.1
 addons:
   apt:
     packages:
     - libzmq3-dev
 cache:
-- apt
-- bundler
+  - apt
+  - bundler
 # Ensure we're running a recent version of bundler
 before_install: gem install bundler --no-rdoc --no-ri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Chef Push Client Changes
 
+## 2.2.0
+
+* Update Ruby from 2.1.8 to 2.2.6
+* Update Chef and Ohai dependencies to latest pre-Chef 13 releases
+
 ## 2.1.4
 
-* Fix bug where a Job with STDOUT/STDERR too large for the server would cause Job to hang. 
+* Fix bug where a Job with STDOUT/STDERR too large for the server would cause Job to hang.
 * Fix Ohai gem constraint causing fresh installations to break due to gem conflicts.
 
 ## 2.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,166 @@
+PATH
+  remote: .
+  specs:
+    opscode-pushy-client (2.2.0)
+      chef (~> 12.19)
+      ffi-rzmq
+      ohai (~> 8.23)
+      uuidtools
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    builder (3.2.3)
+    chef (12.19.36)
+      addressable
+      bundler (>= 1.10)
+      chef-config (= 12.19.36)
+      chef-zero (>= 4.8)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi-yajl (~> 2.2)
+      highline (~> 1.6, >= 1.6.9)
+      iniparse (~> 1.4)
+      mixlib-archive (~> 0.4)
+      mixlib-authentication (~> 1.4)
+      mixlib-cli (~> 1.7)
+      mixlib-log (~> 1.3)
+      mixlib-shellout (~> 2.0)
+      net-sftp (~> 2.1, >= 2.1.2)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (>= 8.6.0.alpha.1, < 13)
+      plist (~> 3.2)
+      proxifier (~> 1.0)
+      rspec-core (~> 3.5)
+      rspec-expectations (~> 3.5)
+      rspec-mocks (~> 3.5)
+      rspec_junit_formatter (~> 0.2.0)
+      serverspec (~> 2.7)
+      specinfra (~> 2.10)
+      syslog-logger (~> 1.6)
+      uuidtools (~> 2.1.5)
+    chef-config (12.19.36)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
+    chef-zero (5.3.1)
+      ffi-yajl (~> 2.2)
+      hashie (>= 2.0, < 4.0)
+      mixlib-log (~> 1.3)
+      rack (~> 2.0)
+      uuidtools (~> 2.1)
+    diff-lcs (1.3)
+    erubis (2.7.0)
+    ffi (1.9.18)
+    ffi-rzmq (2.0.4)
+      ffi-rzmq-core (>= 1.0.1)
+    ffi-rzmq-core (1.0.5)
+      ffi
+    ffi-yajl (2.3.0)
+      libyajl2 (~> 1.2)
+    fuzzyurl (0.9.0)
+    hashie (3.5.5)
+    highline (1.7.8)
+    iniparse (1.4.2)
+    ipaddress (0.8.3)
+    libyajl2 (1.2.0)
+    mixlib-archive (0.4.1)
+      mixlib-log
+    mixlib-authentication (1.4.1)
+      mixlib-log
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.4)
+    mixlib-log (1.7.1)
+    mixlib-shellout (2.2.7)
+    multi_json (1.12.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.1.0)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    net-telnet (0.1.1)
+    ohai (8.23.0)
+      chef-config (>= 12.5.0.alpha.1, < 13)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli
+      mixlib-config (~> 2.0)
+      mixlib-log (>= 1.7.1, < 2.0)
+      mixlib-shellout (~> 2.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    plist (3.2.0)
+    proxifier (1.0.3)
+    public_suffix (2.0.5)
+    rack (2.0.1)
+    rake (12.0.0)
+    rdoc (5.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    serverspec (2.38.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    sfl (2.3)
+    specinfra (2.67.3)
+      net-scp
+      net-ssh (>= 2.7, < 5.0)
+      net-telnet
+      sfl
+    syslog-logger (1.6.8)
+    systemu (2.6.5)
+    uuidtools (2.1.5)
+    wmi-lite (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  opscode-pushy-client!
+  rake
+  rdoc
+  rdp-ruby-wmi
+  rspec
+  rspec_junit_formatter
+  win32-api
+  win32-dir
+  win32-event
+  win32-mutex
+  win32-open3
+  win32-process (>= 0.8.2)
+  win32-service
+  windows-api
+  windows-pr
+
+BUNDLED WITH
+   1.14.6

--- a/lib/pushy_client/version.rb
+++ b/lib/pushy_client/version.rb
@@ -18,6 +18,6 @@
 # Note: the version must also be updated in
 # omnibus/config/projects/push-jobs-client.rb
 class PushyClient
-  VERSION = "2.1.4"
+  VERSION = "2.2.0"
   PROTOCOL_VERSION = "2.0"
 end

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'omnibus', github: 'chef/omnibus'
-gem 'omnibus-software', github: 'chef/omnibus-software'
+gem 'omnibus', git: 'https://github.com/chef/omnibus.git'
+gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git'
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,0 +1,232 @@
+GIT
+  remote: https://github.com/chef/omnibus-software.git
+  revision: 69e7fd212b293795c9a1abf7e2aed3be89ac6d06
+  specs:
+    omnibus-software (4.0.0)
+      chef-sugar (>= 3.4.0)
+      omnibus (>= 5.5.0)
+
+GIT
+  remote: https://github.com/chef/omnibus.git
+  revision: 433220e0b7c434dbc4a36daaa1fecbdb1bf7231d
+  specs:
+    omnibus (5.5.0)
+      aws-sdk (~> 2)
+      chef-sugar (~> 3.3)
+      cleanroom (~> 1.0)
+      ffi-yajl (~> 2.2)
+      license_scout
+      mixlib-shellout (~> 2.0)
+      mixlib-versioning
+      ohai (~> 8.0)
+      pedump
+      ruby-progressbar (~> 1.7)
+      thor (~> 0.18)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    artifactory (2.8.1)
+    awesome_print (1.7.0)
+    aws-sdk (2.8.14)
+      aws-sdk-resources (= 2.8.14)
+    aws-sdk-core (2.8.14)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.8.14)
+      aws-sdk-core (= 2.8.14)
+    aws-sigv4 (1.0.0)
+    berkshelf (5.6.4)
+      addressable (~> 2.3, >= 2.3.4)
+      berkshelf-api-client (>= 2.0.2, < 4.0)
+      buff-config (~> 2.0)
+      buff-extensions (~> 2.0)
+      buff-shell_out (~> 1.0)
+      cleanroom (~> 1.0)
+      faraday (~> 0.9)
+      httpclient (~> 2.7)
+      minitar (~> 0.5, >= 0.5.4)
+      mixlib-archive (~> 0.4)
+      octokit (~> 4.0)
+      retryable (~> 2.0)
+      ridley (~> 5.0)
+      solve (> 2.0, < 4.0)
+      thor (~> 0.19, < 0.19.2)
+    berkshelf-api-client (3.0.0)
+      faraday (~> 0.9)
+      httpclient (~> 2.7)
+      ridley (>= 4.5, < 6.0)
+    buff-config (2.0.0)
+      buff-extensions (~> 2.0)
+      varia_model (~> 0.6)
+    buff-extensions (2.0.0)
+    buff-ignore (1.2.0)
+    buff-ruby_engine (1.0.0)
+    buff-shell_out (1.1.0)
+      buff-ruby_engine (~> 1.0)
+    builder (3.2.3)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    celluloid-io (0.16.2)
+      celluloid (>= 0.16.0)
+      nio4r (>= 1.1.0)
+    chef-config (12.19.36)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
+    chef-sugar (3.4.0)
+    cleanroom (1.0.0)
+    erubis (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.18)
+    ffi-yajl (2.3.0)
+      libyajl2 (~> 1.2)
+    fuzzyurl (0.9.0)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    hashie (3.5.5)
+    hitimes (1.2.4)
+    httpclient (2.8.3)
+    iostruct (0.0.4)
+    ipaddress (0.8.3)
+    jmespath (1.3.1)
+    json (2.0.3)
+    kitchen-vagrant (1.0.2)
+      test-kitchen (~> 1.4)
+    libyajl2 (1.2.0)
+    license_scout (0.1.3)
+      ffi-yajl (~> 2.2)
+      mixlib-shellout (~> 2.2)
+    little-plugger (1.1.4)
+    logging (2.2.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    minitar (0.6.1)
+    mixlib-archive (0.4.1)
+      mixlib-log
+    mixlib-authentication (1.4.1)
+      mixlib-log
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.4)
+    mixlib-install (2.1.12)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+      thor
+    mixlib-log (1.7.1)
+    mixlib-shellout (2.2.7)
+    mixlib-versioning (1.1.0)
+    molinillo (0.5.7)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.1.0)
+    net-ssh-gateway (1.3.0)
+      net-ssh (>= 2.6.5)
+    nio4r (2.0.0)
+    nori (2.6.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    ohai (8.23.0)
+      chef-config (>= 12.5.0.alpha.1, < 13)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli
+      mixlib-config (~> 2.0)
+      mixlib-log (>= 1.7.1, < 2.0)
+      mixlib-shellout (~> 2.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    pedump (0.5.2)
+      awesome_print
+      iostruct (>= 0.0.4)
+      multipart-post (~> 2.0.0)
+      progressbar
+      zhexdump (>= 0.0.2)
+    plist (3.2.0)
+    progressbar (1.8.2)
+    public_suffix (2.0.5)
+    retryable (2.0.4)
+    ridley (5.1.0)
+      addressable
+      buff-config (~> 2.0)
+      buff-extensions (~> 2.0)
+      buff-ignore (~> 1.2)
+      buff-shell_out (~> 1.0)
+      celluloid (~> 0.16.0)
+      celluloid-io (~> 0.16.1)
+      chef-config (>= 12.5.0)
+      erubis
+      faraday (~> 0.9.0)
+      hashie (>= 2.0.2, < 4.0.0)
+      httpclient (~> 2.7)
+      json (>= 1.7.7)
+      mixlib-authentication (>= 1.3.0)
+      retryable (~> 2.0)
+      semverse (~> 2.0)
+      varia_model (~> 0.6)
+    ruby-progressbar (1.8.1)
+    rubyntlm (0.6.1)
+    rubyzip (1.2.1)
+    safe_yaml (1.0.4)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    semverse (2.0.0)
+    solve (3.1.0)
+      molinillo (>= 0.5)
+      semverse (>= 1.1, < 3.0)
+    systemu (2.6.5)
+    test-kitchen (1.16.0)
+      mixlib-install (>= 1.2, < 3.0)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-gateway (~> 1.2)
+      safe_yaml (~> 1.0)
+      thor (~> 0.19, < 0.19.2)
+    thor (0.19.1)
+    timers (4.0.4)
+      hitimes
+    varia_model (0.6.0)
+      buff-extensions (~> 2.0)
+      hashie (>= 2.0.2, < 4.0.0)
+    winrm (2.1.3)
+      builder (>= 2.1.2)
+      erubis (~> 2.7)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0, >= 0.6.1)
+    winrm-fs (1.0.1)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 2.0)
+    wmi-lite (1.0.0)
+    zhexdump (0.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  berkshelf
+  kitchen-vagrant
+  omnibus!
+  omnibus-software!
+  test-kitchen
+  winrm-fs
+
+BUNDLED WITH
+   1.14.6

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -38,15 +38,14 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-# Chef has a loose constraint on Ohai (< 9 for the gem, master for Omnibus),
-# so we can't pin to a specific version otherwise both versions will get
-# installed. Once Ohai hits 9.0, we need to update to a more modern Chef.
-override :chef,           version: "12.8.1"
-override :ohai,           version: "v8.23.0" # pin to tag as master is now Ohai 13
+# TODO: Support chef/ohai master (13)
+override :chef,           version: "v12.19.36" # pin to latest pre-13
+override :ohai,           version: "v8.23.0" # pin to latest pre-13
 
-override :bundler,        version: "1.11.2"
-override :rubygems,       version: "2.5.2"
-override :ruby,           version: "2.1.8"
+override :bundler,        version: "1.12.5"
+override :rubygems,       version: "2.6.10"
+# TODO: Once the omnibus-toolchain is finalized for windows, update this to 2.3
+override :ruby,           version: "2.2.6"
 override :appbundler,     version: "379a06cc58e0d150fb966b49a16df4c70bb9d4d4"
 
 # Short term fix to keep from breaking old client build process

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -44,7 +44,7 @@ override :ohai,           version: "v8.23.0" # pin to latest pre-13
 
 override :bundler,        version: "1.12.5"
 override :rubygems,       version: "2.6.10"
-override :ruby,           version: "2.3.1"
+override :ruby,           version: "2.3.3"
 
 # Share pins with ChefDK
 override :libzmq,         version: "4.0.5"

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -46,7 +46,7 @@ override :bundler,        version: "1.12.5"
 override :rubygems,       version: "2.6.10"
 override :ruby,           version: "2.3.1"
 
-# Short term fix to keep from breaking old client build process
+# Share pins with ChefDK
 override :libzmq,         version: "4.0.5"
 
 ######

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -27,7 +27,7 @@ replace  "opscode-push-jobs-client"
 conflict "opscode-push-jobs-client"
 
 build_iteration 1
-build_version "2.1.4"
+build_version "2.2.0"
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
@@ -44,9 +44,7 @@ override :ohai,           version: "v8.23.0" # pin to latest pre-13
 
 override :bundler,        version: "1.12.5"
 override :rubygems,       version: "2.6.10"
-# TODO: Once the omnibus-toolchain is finalized for windows, update this to 2.3
-override :ruby,           version: "2.2.6"
-override :appbundler,     version: "379a06cc58e0d150fb966b49a16df4c70bb9d4d4"
+override :ruby,           version: "2.3.1"
 
 # Short term fix to keep from breaking old client build process
 override :libzmq,         version: "4.0.5"

--- a/omnibus/config/software/opscode-pushy-client.rb
+++ b/omnibus/config/software/opscode-pushy-client.rb
@@ -39,11 +39,20 @@ end
 
 # For any version other than "local_source", fetch from github.
 if version != "local_source"
-  source git: "git://github.com/chef/opscode-pushy-client"
+  source git: "https://github.com/chef/opscode-pushy-client.git"
 end
 
 relative_path "opscode-pushy-client"
 
+# For nokogiri (via Chef)
+# TODO: Move these deps into omnibus-software chef definition
+dependency "libxml2"
+dependency "libxslt"
+dependency "libiconv"
+dependency "liblzma"
+dependency "zlib"
+
+# Core Requirements
 dependency "rubygems"
 dependency "bundler"
 dependency "appbundler"

--- a/omnibus/config/software/opscode-pushy-client.rb
+++ b/omnibus/config/software/opscode-pushy-client.rb
@@ -65,5 +65,5 @@ build do
       " --no-ri --no-rdoc" \
       " --verbose", env: env
 
-  appbundle 'opscode-pushy-client'
+  appbundle 'opscode-pushy-client', env: env
 end

--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PushyClient::VERSION
 
-  gem.add_dependency "chef", "~> 12.8"
-  gem.add_dependency "ohai", "~> 8.6"
+  gem.add_dependency "chef", "~> 12.19" # pin to latest pre-13
+  gem.add_dependency "ohai", "~> 8.23" # pin to latest pre-13
   gem.add_dependency "ffi-rzmq"
   gem.add_dependency "uuidtools"
 


### PR DESCRIPTION
### Description

The hard dependencies on old Chef, Ruby, and Ohai are causing significant problems for building standalone and in ChefDK. This modernizes the Chef, Ohai, and Ruby that we are using. 

Note: We're not updating to 2.3.1 in the standalone package because that would require us to move to some very nasty long-lived branches of omnibus and omnibus-software. So, instead, we're sticking with 2.2.6 until things settle down. That being said, I did add 2.3.1 to Travis so we can start catching some failures. 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] CHANGELOG.md has been updated
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
