### PR TITLE
Allow non-win platforms to build again.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,47 +43,6 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (13.0.118-universal-mingw32)
-      addressable
-      bundler (>= 1.10)
-      chef-config (= 13.0.118)
-      chef-zero (>= 13.0)
-      diff-lcs (~> 1.2, >= 1.2.4)
-      erubis (~> 2.7)
-      ffi (~> 1.9)
-      ffi-yajl (~> 2.2)
-      highline (~> 1.6, >= 1.6.9)
-      iniparse (~> 1.4)
-      iso8601 (~> 0.9.1)
-      mixlib-archive (~> 0.4)
-      mixlib-authentication (~> 1.4)
-      mixlib-cli (~> 1.7)
-      mixlib-log (~> 1.3)
-      mixlib-shellout (~> 2.0)
-      net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (>= 2.9, < 5.0)
-      net-ssh-multi (~> 1.2, >= 1.2.1)
-      ohai (~> 13.0)
-      plist (~> 3.2)
-      proxifier (~> 1.0)
-      rspec-core (~> 3.5)
-      rspec-expectations (~> 3.5)
-      rspec-mocks (~> 3.5)
-      rspec_junit_formatter (~> 0.2.0)
-      serverspec (~> 2.7)
-      specinfra (~> 2.10)
-      syslog-logger (~> 1.6)
-      uuidtools (~> 2.1.5)
-      win32-api (~> 1.5.3)
-      win32-dir (~> 0.5.0)
-      win32-event (~> 0.6.1)
-      win32-eventlog (= 0.6.3)
-      win32-mmap (~> 0.4.1)
-      win32-mutex (~> 0.4.2)
-      win32-process (~> 0.8.2)
-      win32-service (~> 0.8.7)
-      windows-api (~> 0.4.4)
-      wmi-lite (~> 1.0)
     chef-config (13.0.118)
       addressable
       fuzzyurl
@@ -98,12 +57,9 @@ GEM
     diff-lcs (1.3)
     erubis (2.7.0)
     ffi (1.9.18)
-    ffi (1.9.18-x86-mingw32)
     ffi-rzmq (2.0.5)
       ffi-rzmq-core (>= 1.0.6)
     ffi-rzmq-core (1.0.6)
-      ffi
-    ffi-win32-extensions (1.0.3)
       ffi
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
@@ -122,9 +78,6 @@ GEM
     mixlib-config (2.2.4)
     mixlib-log (1.7.1)
     mixlib-shellout (2.2.7)
-    mixlib-shellout (2.2.7-universal-mingw32)
-      win32-process (~> 0.8.2)
-      wmi-lite (~> 1.0)
     multi_json (1.12.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -149,29 +102,28 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    plist (3.2.0)
+    plist (3.3.0)
     proxifier (1.0.3)
     public_suffix (2.0.5)
-    rack (2.0.1)
+    rack (2.0.2)
     rake (12.0.0)
     rdoc (5.1.0)
-    rdp-ruby-wmi (0.3.1)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
+      rspec-support (~> 3.6.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.5.0)
+    rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -181,7 +133,7 @@ GEM
       rspec-its
       specinfra (~> 2.53)
     sfl (2.3)
-    specinfra (2.67.8)
+    specinfra (2.67.9)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -189,36 +141,10 @@ GEM
     syslog-logger (1.6.8)
     systemu (2.6.5)
     uuidtools (2.1.5)
-    win32-api (1.5.3-universal-mingw32)
-    win32-dir (0.5.1)
-      ffi (>= 1.0.0)
-    win32-event (0.6.3)
-      win32-ipc (>= 0.6.0)
-    win32-eventlog (0.6.3)
-      ffi
-    win32-ipc (0.7.0)
-      ffi
-    win32-mmap (0.4.2)
-      ffi
-    win32-mutex (0.4.3)
-      win32-ipc (>= 0.6.0)
-    win32-open3 (0.3.2-x86-mingw32)
-    win32-process (0.8.3)
-      ffi (>= 1.0.0)
-    win32-service (0.8.10)
-      ffi
-      ffi-win32-extensions
-    windows-api (0.4.4)
-      win32-api (>= 1.4.5)
-    windows-pr (1.2.6)
-      win32-api (>= 1.4.5)
-      windows-api (>= 0.4.0)
     wmi-lite (1.0.0)
 
 PLATFORMS
   ruby
-  x86-mingw32
-  x86-mswin32
 
 DEPENDENCIES
   ffi
@@ -239,4 +165,4 @@ DEPENDENCIES
   windows-pr
 
 BUNDLED WITH
-   1.14.6
+   1.13.6

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -27,7 +27,7 @@ replace  "opscode-push-jobs-client"
 conflict "opscode-push-jobs-client"
 
 build_iteration 1
-build_version "2.2.0"
+build_version "2.3.0"
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
@@ -38,13 +38,15 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-# TODO: Support chef/ohai master (13)
-override :chef,           version: "v12.19.36" # pin to latest pre-13
-override :ohai,           version: "v8.23.0" # pin to latest pre-13
+# Using pins that agree with chef 13.0.118.
+override :chef,           version: "v13.0.118"
+override :ohai,           version: "v13.0.1"
 
-override :bundler,        version: "1.12.5"
-override :rubygems,       version: "2.6.10"
-override :ruby,           version: "2.3.3"
+# Need modern bundler if we wish to support x-plat Gemfile.lock.
+# Otherwise win32-api pins for windows will break non-windows builds for bundler < 1.14.
+override :bundler,        version: "1.13.7"
+override :rubygems,       version: "2.6.12"
+override :ruby,           version: "2.4.1"
 
 # Share pins with ChefDK
 override :libzmq,         version: "4.0.5"


### PR DESCRIPTION
Signed-off-by: Kartik Null Cating-Subramanian <ksubramanian@chef.io>

### Description

We need bundler > 1.14 to allow non-windows platforms to build under omnibus.  Otherwise they fail trying to install win32-* gems.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] CHANGELOG.md has been updated
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
