### PR TITLE
Allow push jobs to build libzmq from source on windows

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -18,6 +18,13 @@ driver:
 provisioner:
   name: chef_zero
   require_chef_omnibus: true # Always install the latest version of Chef
+  attributes:
+    vagrant:
+      this_key_exists_so_we_have_a_vagrant_key: true
+    omnibus:
+      build_user:          vagrant
+      build_user_group:    vagrant
+      build_user_password: vagrant
 
 platforms:
   - name: centos-5.10
@@ -64,35 +71,48 @@ platforms:
   # as the default provider by copying `.kitchen.local.yml.vmware.example`
   # over to `.kitchen.local.yml`.
   #
-  - name: macosx-10.8
+  <% %w(
+    10.9
+    10.10
+    10.11
+  ).each do |mac_version| %>
+  - name: macosx-<%= mac_version %>
     driver:
-      box: chef/macosx-10.8 # private
-  - name: macosx-10.9
+      box: chef/macosx-<%= mac_version %> # private
+      synced_folders:
+        - ['..', '/Users/vagrant/opscode-pushy-client']
+        - ['../../omnibus', '/Users/vagrant/omnibus']
+        - ['../../omnibus-software', '/Users/vagrant/omnibus-software']
+  <% end %>
+  - name: windows-2012r2-standard
     driver:
-      box: chef/macosx-10.9 # private
-  - name: macosx-10.10
+      box: chef/windows-server-2012r2-standard # private
+      synced_folders:
+        - ['../..', '/vagrant/code']
+    provisioner:
+      attributes:
+        omnibus:
+          build_user:          vagrant
+          build_user_group:    Administrators
+          build_user_password: vagrant
+  # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
+  # will load the 32-bit version of the MinGW toolchain.
+  - name: windows-2012r2-standard-i386
     driver:
-      box: chef/macosx-10.10 # private
-  - name: windows-7-professional
-    driver:
-      box: chef/windows-7-professional # private
-  - name: windows-8.1-professional
-    driver:
-      box: chef/windows-8.1-professional # private
-  - name: windows-2008r2-standard
-    driver:
-      box: chef/windows-server-2008r2-standard # private
-
-attribute_defaults: &attribute_defaults
-  build_user:          vagrant
-  build_user_group:    vagrant
-  build_user_password: vagrant
+      box: chef/windows-server-2012r2-standard # private
+      synced_folders:
+        - ['../..', '/vagrant/code']
+    provisioner:
+      attributes:
+        omnibus:
+          build_user:          vagrant
+          build_user_group:    Administrators
+          build_user_password: vagrant
 
 suites:
   - name: push-jobs-client
     attributes:
       omnibus:
-        <<: *attribute_defaults
         install_dir: /opt/push-jobs-client
     run_list:
       - omnibus::default

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 1a163c64a9d6d0646e17bdd637966e0a398d4b08
+  revision: ecc5d6cb06610ae5b3c098d0ad32d1d202f47b4f
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 78b14bacba818c78e08b9b007be42b966b2aafe3
+  revision: 2215d10c1d13c30f058f126806bff09807706c41
   specs:
     omnibus (5.6.1)
       aws-sdk (~> 2)
@@ -30,19 +30,18 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.8.2)
     awesome_print (1.8.0)
-    aws-sdk (2.10.2)
-      aws-sdk-resources (= 2.10.2)
-    aws-sdk-core (2.10.2)
+    aws-sdk (2.10.17)
+      aws-sdk-resources (= 2.10.17)
+    aws-sdk-core (2.10.17)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.2)
-      aws-sdk-core (= 2.10.2)
-    aws-sigv4 (1.0.0)
-    berkshelf (6.2.0)
-      addressable (~> 2.3, >= 2.3.4)
-      berkshelf-api-client (>= 4.0.0)
+    aws-sdk-resources (2.10.17)
+      aws-sdk-core (= 2.10.17)
+    aws-sigv4 (1.0.1)
+    berkshelf (6.2.1)
       buff-config (~> 2.0)
       buff-extensions (~> 2.0)
+      chef (>= 12.7.2)
       cleanroom (~> 1.0)
       concurrent-ruby (~> 1.0)
       faraday (~> 0.9)
@@ -55,8 +54,6 @@ GEM
       ridley (~> 5.0)
       solve (> 2.0, < 4.0)
       thor (~> 0.19, < 0.19.2)
-    berkshelf-api-client (4.0.0)
-      chef (>= 12.0)
     buff-config (2.0.0)
       buff-extensions (~> 2.0)
       varia_model (~> 0.6)
@@ -105,7 +102,7 @@ GEM
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
-    chef-sugar (3.4.0)
+    chef-sugar (3.5.0)
     chef-zero (5.3.2)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -116,7 +113,7 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
-    faraday (0.12.1)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     ffi-yajl (2.3.1)
@@ -126,16 +123,16 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.5)
+    hashie (3.5.6)
     highline (1.7.8)
     hitimes (1.2.5)
     httpclient (2.8.3)
-    iniparse (1.4.3)
+    iniparse (1.4.4)
     iostruct (0.0.4)
     ipaddress (0.8.3)
     jmespath (1.3.1)
     json (2.1.0)
-    kitchen-vagrant (1.1.0)
+    kitchen-vagrant (1.1.1)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     license_scout (0.1.3)
@@ -158,8 +155,8 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (1.7.1)
-    mixlib-shellout (2.2.7)
-    mixlib-versioning (1.1.0)
+    mixlib-shellout (2.3.2)
+    mixlib-versioning (1.2.1)
     molinillo (0.5.7)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -256,7 +253,7 @@ GEM
     solve (3.1.0)
       molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.68.0)
+    specinfra (2.70.0)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -307,4 +304,4 @@ DEPENDENCIES
   winrm-fs
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -43,13 +43,18 @@ override :chef,           version: "v13.0.118"
 override :ohai,           version: "v13.0.1"
 
 # Need modern bundler if we wish to support x-plat Gemfile.lock.
-# Otherwise win32-api pins for windows will break non-windows builds for bundler < 1.14.
+# Unfortunately, 1.14.x series has issues with BUNDLER_VERSION variables exported by
+# the omnibus cookbook. Bump to it after the builders no longer set that environment
+# variable.
 override :bundler,        version: "1.13.7"
 override :rubygems,       version: "2.6.12"
 override :ruby,           version: "2.4.1"
 
-# Share pins with ChefDK
-override :libzmq,         version: "4.0.5"
+# Default in omnibus-software was too old.  Feel free to move this ahead as necessary.
+override :libsodium,      version: "1.0.12"
+# Pick last version in 4.0.x that we have tested on windows.
+# Feel free to bump this if you're willing to test out a newer version.
+override :libzmq,         version: "4.0.7"
 
 ######
 

--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -27,7 +27,11 @@ replace  "opscode-push-jobs-client"
 conflict "opscode-push-jobs-client"
 
 build_version IO.read(File.expand_path("../../../../VERSION", __FILE__)).strip
-build_iteration 1
+
+# In order to prevent unecessary cache expiration, version overrides
+# and build_iteration are kept in <project-root>/omnibus_overrides.rb
+overrides_path = File.expand_path("../../../../omnibus_overrides.rb", __FILE__)
+instance_eval(IO.read(overrides_path), overrides_path)
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
@@ -37,26 +41,6 @@ if windows?
 else
   install_dir "#{default_root}/#{name}"
 end
-
-# Using pins that agree with chef 13.0.118.
-override :chef,           version: "v13.0.118"
-override :ohai,           version: "v13.0.1"
-
-# Need modern bundler if we wish to support x-plat Gemfile.lock.
-# Unfortunately, 1.14.x series has issues with BUNDLER_VERSION variables exported by
-# the omnibus cookbook. Bump to it after the builders no longer set that environment
-# variable.
-override :bundler,        version: "1.13.7"
-override :rubygems,       version: "2.6.12"
-override :ruby,           version: "2.4.1"
-
-# Default in omnibus-software was too old.  Feel free to move this ahead as necessary.
-override :libsodium,      version: "1.0.12"
-# Pick last version in 4.0.x that we have tested on windows.
-# Feel free to bump this if you're willing to test out a newer version.
-override :libzmq,         version: "4.0.7"
-
-######
 
 dependency "preparation"
 dependency "rb-readline"

--- a/omnibus/config/software/opscode-pushy-client.rb
+++ b/omnibus/config/software/opscode-pushy-client.rb
@@ -50,7 +50,7 @@ dependency "libxml2"
 dependency "libxslt"
 dependency "libiconv"
 dependency "liblzma"
-dependency "zlib"
+dependency "libzmq"
 
 # Core Requirements
 dependency "rubygems"
@@ -58,12 +58,6 @@ dependency "bundler"
 dependency "appbundler"
 dependency "chef"
 dependency "openssl-customization"
-
-if windows?
-  dependency "libzmq4x-windows"
-else
-  dependency "libzmq"
-end
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/resources/push-jobs-client/msi/source.wxs.erb
+++ b/omnibus/resources/push-jobs-client/msi/source.wxs.erb
@@ -91,8 +91,11 @@
                                   Arguments="[PROJECTLOCATION]$(var.PushJobsGemPath)\lib\pushy_client\windows_service.rb"
                                   DisplayName="!(loc.ServiceDisplayName)"
                                   Description="!(loc.ServiceDescription)" />
-                  <ServiceControl Id="ControlPushJobsClientService" Name="push-jobs-client"
-                                  Remove="both" Start="install" Stop="both" Wait="no" />
+                  <ServiceControl Id="ControlPushJobsClientService"
+                                  Name="push-jobs-client"
+                                  Remove="both"
+                                  Stop="both"
+                                  Wait="no" />
                 </Component>
               </Directory>
             </Directory>

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,0 +1,19 @@
+build_iteration 1
+
+# Using pins that agree with chef 13.0.118.
+override :chef,           version: "v13.0.118"
+override :ohai,           version: "v13.0.1"
+
+# Need modern bundler if we wish to support x-plat Gemfile.lock.
+# Unfortunately, 1.14.x series has issues with BUNDLER_VERSION variables exported by
+# the omnibus cookbook. Bump to it after the builders no longer set that environment
+# variable.
+override :bundler,        version: "1.13.7"
+override :rubygems,       version: "2.6.12"
+override :ruby,           version: "2.4.1"
+
+# Default in omnibus-software was too old.  Feel free to move this ahead as necessary.
+override :libsodium,      version: "1.0.12"
+# Pick last version in 4.0.x that we have tested on windows.
+# Feel free to bump this if you're willing to test out a newer version.
+override :libzmq,         version: "4.0.7"


### PR DESCRIPTION
### Description

See chef/omnibus-software#830 for details.  Don't merge until that goes in.

Also updates .kitchen.yml to build windows-2012r2 because we don't use win 2008 builders in the CI anymore.

### Issues Resolved

Resolves #125 (I hope :-P)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] CHANGELOG.md has been updated
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
