### PR TITLE
Update SHA1 fingerprint for MSI signing cert

### DIFF
--- a/omnibus/config/projects/push-jobs-client.rb
+++ b/omnibus/config/projects/push-jobs-client.rb
@@ -73,7 +73,7 @@ package :msi do
   fast_msi true
   # Upgrade code for Chef MSI
   upgrade_code "D607A85C-BDFA-4F08-83ED-2ECB4DCD6BC5"
-  signing_identity "F74E1A68005E8A9C465C3D2FF7B41F3988F0EA09", machine_store: true
+  signing_identity "E05FF095D07F233B78EB322132BFF0F035E11B5B", machine_store: true
 
   parameters(
     ProjectLocationDir: 'push-jobs-client',


### PR DESCRIPTION
The cert has been updated as the old one expires on 2017-07-25.

Signed-off-by: Seth Chisamore <schisamo@chef.io>