### PR TITLE
Wrap ZMQ request in timeout

### DIFF
--- a/lib/pushy_client/periodic_reconfigurer.rb
+++ b/lib/pushy_client/periodic_reconfigurer.rb
@@ -43,7 +43,7 @@ class PushyClient
     # set the reconfigure deadline to some future number of seconds (with a splay applied)
     def update_reconfigure_deadline(delay)
       @lock.synchronize do
-        @reconfigure_deadline = Time.now + delay * (1 - prng.rand(SPLAY))
+        @reconfigure_deadline = Time.now + delay * (1 - @prng.rand(SPLAY))
         Chef::Log.info "[#{node_name}] Setting reconfigure deadline to #{@reconfigure_deadline}"
       end
     end

--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -483,8 +483,14 @@ class PushyClient
              when :hmac_sha256
                make_header_hmac(message, session_key)
              end
-      socket.send_string(auth, ZMQ::SNDMORE)
-      socket.send_string(message)
+      begin
+        timeout(10) do
+          socket.send_string(auth, ZMQ::SNDMORE)
+          socket.send_string(message)
+        end
+      rescue
+        Chef::Log.info("ZMQ socket timed out")
+      end
     end
 
     def self.load_key(key_path)

--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -484,11 +484,11 @@ class PushyClient
                make_header_hmac(message, session_key)
              end
       begin
-        timeout(10) do
+        Timeout.timeout(10) do
           socket.send_string(auth, ZMQ::SNDMORE)
           socket.send_string(message)
         end
-      rescue
+      rescue Timeout::Error
         Chef::Log.info("ZMQ socket timed out")
       end
     end

--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -489,7 +489,9 @@ class PushyClient
           socket.send_string(message)
         end
       rescue Timeout::Error
-        Chef::Log.info("ZMQ socket timed out")
+        Chef::Log.info("[#{node_name}] ZMQ socket timed out. Triggering reconfigure")
+        # we don't immediately reconfigure because this is likely to amplify any stampedes. 
+        client.periodicReconfigurer.update_reconfigure_deadline(60)
       end
     end
 


### PR DESCRIPTION


Signed-off-by: Nolan Davidson <ndavidson@chef.io>

### Description

As noted in #123, the push jobs client will sometimes hang on the
send_string call when the push jobs server is restarted (or is replaced
by another PJ server).  After adding this timeout, I have been able to
successfully restart and replace the PJ server without the client
hanging consistently.

### Issues Resolved

#123 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] CHANGELOG.md has been updated
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
