### PR TITLE
Quick hack at a reconfigure strategy

### DIFF
--- a/lib/pushy_client/protocol_handler.rb
+++ b/lib/pushy_client/protocol_handler.rb
@@ -489,7 +489,9 @@ class PushyClient
           socket.send_string(message)
         end
       rescue Timeout::Error
-        Chef::Log.info("ZMQ socket timed out")
+        Chef::Log.info("[#{node_name}] ZMQ socket timed out. Triggering reconfigure")
+        # we don't immediately reconfigure because this is likely to amplify any stampedes. 
+        client.periodicReconfigurer.update_reconfigure_deadline(60)
       end
     end
 


### PR DESCRIPTION
WIP, for reference and commentary as I have done ZERO TESTING on this.

This modifies the periodic reconfigure loop to allow us to alter the
reconfigure timeout, and makes packet send timeouts advance the reconfigure deadline.

It seems probable if we are timing out in zeromq, we have a broken
connection (as if we failed to recieve heartbeats) and should treat it
the same way.

Signed-off-by: Mark Anderson <mark@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] CHANGELOG.md has been updated
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
