### PR TITLE
Update ruby to 2.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
-    chef (13.3.42)
+    chef (13.4.19)
       addressable
       bundler (>= 1.10)
-      chef-config (= 13.3.42)
+      chef-config (= 13.4.19)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -43,7 +43,7 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (13.3.42)
+    chef-config (13.4.19)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -105,7 +105,7 @@ GEM
     proxifier (1.0.3)
     public_suffix (3.0.0)
     rack (2.0.3)
-    rake (12.0.0)
+    rake (12.1.0)
     rdoc (5.1.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -164,4 +164,4 @@ DEPENDENCIES
   windows-pr
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: ecc5d6cb06610ae5b3c098d0ad32d1d202f47b4f
+  revision: 34e176df09ad80a49cbf516f18b108a48fc76d15
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 2215d10c1d13c30f058f126806bff09807706c41
+  revision: 52393d7cab443b61790f94c62775d9032d283497
   specs:
     omnibus (5.6.1)
       aws-sdk (~> 2)
@@ -26,19 +26,19 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     artifactory (2.8.2)
     awesome_print (1.8.0)
-    aws-sdk (2.10.17)
-      aws-sdk-resources (= 2.10.17)
-    aws-sdk-core (2.10.17)
+    aws-sdk (2.10.45)
+      aws-sdk-resources (= 2.10.45)
+    aws-sdk-core (2.10.45)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.17)
-      aws-sdk-core (= 2.10.17)
-    aws-sigv4 (1.0.1)
-    berkshelf (6.2.1)
+    aws-sdk-resources (2.10.45)
+      aws-sdk-core (= 2.10.45)
+    aws-sigv4 (1.0.2)
+    berkshelf (6.3.1)
       buff-config (~> 2.0)
       buff-extensions (~> 2.0)
       chef (>= 12.7.2)
@@ -52,7 +52,7 @@ GEM
       octokit (~> 4.0)
       retryable (~> 2.0)
       ridley (~> 5.0)
-      solve (> 2.0, < 4.0)
+      solve (~> 4.0)
       thor (~> 0.19, < 0.19.2)
     buff-config (2.0.0)
       buff-extensions (~> 2.0)
@@ -68,10 +68,10 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef (12.21.1)
+    chef (12.21.10)
       addressable
       bundler (>= 1.10)
-      chef-config (= 12.21.1)
+      chef-config (= 12.21.10)
       chef-zero (>= 4.8, < 13)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -97,7 +97,7 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (12.21.1)
+    chef-config (12.21.10)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -113,7 +113,7 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
-    faraday (0.12.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     ffi-yajl (2.3.1)
@@ -125,14 +125,14 @@ GEM
       builder (>= 2.1.2)
     hashie (3.5.6)
     highline (1.7.8)
-    hitimes (1.2.5)
+    hitimes (1.2.6)
     httpclient (2.8.3)
     iniparse (1.4.4)
     iostruct (0.0.4)
     ipaddress (0.8.3)
     jmespath (1.3.1)
     json (2.1.0)
-    kitchen-vagrant (1.1.1)
+    kitchen-vagrant (1.2.1)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     license_scout (0.1.3)
@@ -145,8 +145,7 @@ GEM
     minitar (0.6.1)
     mixlib-archive (0.4.1)
       mixlib-log
-    mixlib-authentication (1.4.1)
-      mixlib-log
+    mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
     mixlib-install (2.1.12)
@@ -156,15 +155,15 @@ GEM
       thor
     mixlib-log (1.7.1)
     mixlib-shellout (2.3.2)
-    mixlib-versioning (1.2.1)
-    molinillo (0.5.7)
-    multi_json (1.12.1)
+    mixlib-versioning (1.2.2)
+    molinillo (0.6.3)
+    multi_json (1.12.2)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (4.1.0)
+    net-ssh (4.2.0)
     net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.2.1)
@@ -196,7 +195,7 @@ GEM
     plist (3.3.0)
     progressbar (1.8.2)
     proxifier (1.0.3)
-    public_suffix (2.0.5)
+    public_suffix (3.0.0)
     rack (2.0.3)
     retryable (2.0.4)
     ridley (5.1.1)
@@ -236,7 +235,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.8.3)
     rubyntlm (0.6.2)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
@@ -244,23 +243,23 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     semverse (2.0.0)
-    serverspec (2.39.1)
+    serverspec (2.40.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.68)
     sfl (2.3)
-    solve (3.1.0)
-      molinillo (>= 0.5)
+    solve (4.0.0)
+      molinillo (~> 0.6)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.70.0)
+    specinfra (2.71.2)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
       sfl
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.16.0)
+    test-kitchen (1.17.0)
       mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -304,4 +303,4 @@ DEPENDENCIES
   winrm-fs
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,8 +9,8 @@ override :ohai,           version: "v13.0.1"
 # the omnibus cookbook. Bump to it after the builders no longer set that environment
 # variable.
 override :bundler,        version: "1.13.7"
-override :rubygems,       version: "2.6.12"
-override :ruby,           version: "2.4.1"
+override :rubygems,       version: "2.6.13"
+override :ruby,           version: "2.4.2"
 
 # Default in omnibus-software was too old.  Feel free to move this ahead as necessary.
 override :libsodium,      version: "1.0.12"


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@opscode.com>

### Description

Update ruby to 2.4.2

### Issues Resolved

https://www.ruby-lang.org/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] CHANGELOG.md has been updated
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
