### PR TITLE
expeditor config: bundle update every time

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -9,4 +9,6 @@ set -evx
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/pushy_client/version.rb
 
 # Ensure our Gemfile.lock reflects the new version
-bundle update opscode-pushy-client
+#bundle update opscode-pushy-client
+# XXX: for now we update everything continuously because bundler is buggy
+bundle update


### PR DESCRIPTION
bundler is buggy and is crashing on `bundle update opscode-pushy-client`
right now with:

```
% bundle update opscode-pushy-client
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "win32-api":
  In snapshot (Gemfile.lock):
    win32-api (= 1.5.3)

  In Gemfile:
    win32-api x86-mingw32

    windows-pr x86-mingw32 was resolved to 1.2.6, which depends on
      win32-api (>= 1.4.5)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

which is incorrect, because win32-api 1.5.3 is >= 1.4.5.

