### PR TITLE
MSYS-832 - Added feature that end user can configure STDER/STDOUT size

### DIFF
--- a/.chef/push-jobs-client.rb
+++ b/.chef/push-jobs-client.rb
@@ -3,11 +3,13 @@ current_dir = File.expand_path(File.dirname(__FILE__))
 chef_server_url "https://api.chef-server.dev/organizations/push-client-local"
 log_location STDOUT
 ssl_verify_mode :verify_none
+max_body_size	63000
 
 node_name "push-client-dev-local"
 client_key "#{current_dir}/push-client-dev-local.pem"
 
 trusted_certs_dir "#{current_dir}/trusted_certs"
+
 whitelist {
 
 }

--- a/lib/pushy_client.rb
+++ b/lib/pushy_client.rb
@@ -37,6 +37,7 @@ class PushyClient
     @file_dir        = options[:file_dir] || '/tmp/pushy'
     @file_dir_expiry = options[:file_dir_expiry] || 86400
     @allowed_overwritable_env_vars = options[:allowed_overwritable_env_vars]
+    @max_body_size   = options[:max_body_size] || 63000
 
     @allow_unencrypted = options[:allow_unencrypted] || false
     @client_curve_pub_key, @client_curve_sec_key = ZMQ::Util.curve_keypair
@@ -75,6 +76,7 @@ class PushyClient
   attr_accessor :node_name
   attr_accessor :hostname
   attr_accessor :whitelist
+  attr_accessor :max_body_size
   attr_reader :incarnation_id
   attr_reader :legacy_mode # indicate we've fallen back to 1.x
   attr_reader :allowed_overwritable_env_vars

--- a/lib/pushy_client/cli.rb
+++ b/lib/pushy_client/cli.rb
@@ -70,6 +70,12 @@ class PushyClient
       :description => "The node name for this client",
       :proc => nil
 
+    option :max_body_size,
+      :short => "-M MAX_BODY_SIZE",
+      :long => "--max-body-size MAX_BODY_SIZE",
+      :description => "MAX_BODY_SIZE of STDER/SDTOUT for this client",
+      :proc => nil
+
     option :chef_server_url,
       :short => "-S CHEFSERVERURL",
       :long => "--server CHEFSERVERURL",
@@ -133,7 +139,8 @@ class PushyClient
         :hostname        => ohai[:hostname],
         :filedir         => Chef::Config[:file_dir],
         :allow_unencrypted => Chef::Config[:allow_unencrypted],
-        :allowed_overwritable_env_vars => Chef::Config[:allowed_overwritable_env_vars]
+        :allowed_overwritable_env_vars => Chef::Config[:allowed_overwritable_env_vars],
+        :max_body_size   => Chef::Config[:max_body_size]
       )
 
       @client.start

--- a/spec/pushy_client/protocol_handler_spec.rb
+++ b/spec/pushy_client/protocol_handler_spec.rb
@@ -18,7 +18,7 @@ describe PushyClient::ProtocolHandler do
       allow(client).to receive(:hostname)
       allow(client).to receive(:org_name)
       allow(client).to receive(:incarnation_id)
-      allow(client).to receive(:max_body_size)
+      allow(client).to receive(:max_body_size).and_return(63000)
       allow_any_instance_of(described_class).to receive(:send_signed_json_command)
       allow(Chef::Log).to receive(:warn)
     end
@@ -33,7 +33,7 @@ describe PushyClient::ProtocolHandler do
 
       it "logs a warning" do
         expect(Chef::Log).to receive(:warn).with(
-          "Command output too long. Will not be sent to server."
+          "Command output #{params[:stdout].to_s.bytesize + params[:stderr].to_s.bytesize} is larger than the Client MAX_BODY_SIZE of #{client.max_body_size.to_i}"
         )
         send_command
       end

--- a/spec/pushy_client/protocol_handler_spec.rb
+++ b/spec/pushy_client/protocol_handler_spec.rb
@@ -18,6 +18,7 @@ describe PushyClient::ProtocolHandler do
       allow(client).to receive(:hostname)
       allow(client).to receive(:org_name)
       allow(client).to receive(:incarnation_id)
+      allow(client).to receive(:max_body_size)
       allow_any_instance_of(described_class).to receive(:send_signed_json_command)
       allow(Chef::Log).to receive(:warn)
     end


### PR DESCRIPTION
### Description

Provide option that user can configure the max_body_size in `push-jobs-client.rb`. Default max_body_size is `63000`, also user can provide options as `--max-body-size` at runtime.


Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>
