### PR TITLE
Expeditor: use our standard labels and auto delete branches

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,4 +1,6 @@
-# Documentation available at http://expeditor-docs.es.chef.io/
+# Documentation available at https://expeditor.chef.io/docs/getting-started/
+
+# The name of the product keys for this product (from mixlib-install)
 product_key: push-jobs-client
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
@@ -6,19 +8,32 @@ slack:
   notify_channel: chef-server-notify
 
 github:
-  maintainer_group: chef/sustaining-eng-team
+  # This deletes the GitHub PR branch after successfully merged into the release branch
+  delete_branch_on_merge: true
+  # allow bumping the minor release via label
+  minor_bump_labels:
+    - "Expeditor: Bump Minor Version"
 
+# These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:
-      ignore_labels: "Version: Skip Bump"
+      ignore_labels:
+        - "Expeditor: Skip Version Bump"
+        - "Expeditor: Skip All"
   - bash:.expeditor/update_version.sh:
       only_if: built_in:bump_version
   - built_in:update_changelog:
-      ignore_labels: "Changelog: Skip Update"
+      ignore_labels:
+        - "Expeditor: Exclude From Changelog"
+        - "Expeditor: Skip All"
   - built_in:trigger_omnibus_release_build:
-      ignore_labels: "Omnibus: Skip Build"
+      ignore_labels:
+        - "Expeditor: Skip Build"
+        - "Expeditor: Skip All"
       only_if: built_in:bump_version
 
+# These actions are taken, in the order specified, when an Omnibus artifact is promoted
+# within Chef's internal artifact storage system.
 artifact_actions:
   promoted_to_stable:
     - built_in:rollover_changelog


### PR DESCRIPTION
We were missing some configs around skipping all as well, which is a very useful label to use.

Signed-off-by: Tim Smith <tsmith@chef.io>