### PR TITLE
Add the github lock bot and fix the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ StackOverflow discussion that's relevant]
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
-- [ ] CHANGELOG.md has been updated
+- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
 - [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,1 @@
+daysUntilLock: 60


### PR DESCRIPTION
The changelog is auto managed so we don't want people to update that.

Signed-off-by: Tim Smith <tsmith@chef.io>