### PR TITLE
Fixed issue with file directory not being read properly from the config file.

### DIFF
--- a/lib/pushy_client/cli.rb
+++ b/lib/pushy_client/cli.rb
@@ -131,7 +131,7 @@ class PushyClient
         :node_name       => Chef::Config[:node_name] || ohai[:fqdn] || ohai[:hostname],
         :whitelist       => Chef::Config[:whitelist] || { 'chef-client' => 'chef-client' },
         :hostname        => ohai[:hostname],
-        :filedir         => Chef::Config[:file_dir],
+        :file_dir         => Chef::Config[:file_dir],
         :allow_unencrypted => Chef::Config[:allow_unencrypted],
         :allowed_overwritable_env_vars => Chef::Config[:allowed_overwritable_env_vars]
       )

--- a/lib/pushy_client/windows_service.rb
+++ b/lib/pushy_client/windows_service.rb
@@ -73,6 +73,7 @@ class PushyClient
                                     :node_name       => Chef::Config[:node_name] || ohai[:fqdn] || ohai[:hostname],
                                     :whitelist       => Chef::Config[:whitelist] || { 'chef-client' => 'chef-client' },
                                     :hostname        => ohai[:hostname],
+                                    :file_dir        => Chef::Config[:file_dir],
                                     :allow_unencrypted => Chef::Config[:allow_unencrypted]
                                     )
 


### PR DESCRIPTION
Fixed issue with file directory not being read properly from the config file.

Obvious fix.

### Description

[Please describe what this change achieves]
It seems like windows service of the pushy client never reads the file_dir value from the config file and always defaults to "tmp/pushy". As a result, windows nodes always fail to process the push job that specifies file since that directory almost certainly does not exists and the push client fails to create it either.

### Issues Resolved
[169](https://github.com/chef/opscode-pushy-client/issues/169)
### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
