### PR TITLE
Require Chef 13 or later and allow Chef 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6
 addons:
   apt:
     packages:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     opscode-pushy-client (2.5.8)
-      chef (>= 12.19, < 15.0)
+      chef (>= 13.0, < 16.0)
       ffi-rzmq
-      ohai (>= 8.23, < 15.0)
+      ohai (>= 13.0, < 16.0)
       uuidtools
 
 GEM
@@ -13,10 +13,10 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
-    chef (14.6.47)
+    chef (14.8.12)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.6.47)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -43,10 +43,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.6.47-universal-mingw32)
+    chef (14.8.12-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.6.47)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -75,6 +75,7 @@ GEM
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
+      win32-certstore (>= 0.1.8)
       win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
@@ -85,17 +86,17 @@ GEM
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.6.47)
+    chef-config (14.8.12)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-zero (14.0.6)
+    chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 2.0)
-      rack (~> 2.0)
+      rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
     diff-lcs (1.3)
     erubis (2.7.0)
@@ -117,17 +118,17 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     libyajl2 (1.2.0)
-    mixlib-archive (0.4.18)
+    mixlib-archive (0.4.19)
       mixlib-log
-    mixlib-archive (0.4.18-universal-mingw32)
+    mixlib-archive (0.4.19-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
-    mixlib-log (2.0.4)
-    mixlib-shellout (2.4.0)
-    mixlib-shellout (2.4.0-universal-mingw32)
+    mixlib-log (2.0.9)
+    mixlib-shellout (2.4.4)
+    mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     multi_json (1.13.1)
@@ -142,7 +143,7 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
-    ohai (14.6.2)
+    ohai (14.8.10)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -157,8 +158,8 @@ GEM
     plist (3.4.0)
     proxifier (1.0.3)
     public_suffix (3.0.3)
-    rack (2.0.5)
-    rake (12.3.1)
+    rack (2.0.6)
+    rake (12.3.2)
     rdp-ruby-wmi (0.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -185,7 +186,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    specinfra (2.76.3)
+    specinfra (2.76.5)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -196,6 +197,9 @@ GEM
     tomlrb (1.2.7)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)
+    win32-certstore (0.1.11)
+      ffi
+      mixlib-shellout
     win32-dir (0.5.1)
       ffi (>= 1.0.0)
     win32-event (0.6.3)
@@ -222,7 +226,7 @@ GEM
     windows-pr (1.2.6)
       win32-api (>= 1.4.5)
       windows-api (>= 0.4.0)
-    wmi-lite (1.0.0)
+    wmi-lite (1.0.1)
     yard (0.9.16)
 
 PLATFORMS
@@ -249,4 +253,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 3b6ef4c42d8c2f9f9e1c6e285b2ea48e0d0f0fdd
+  revision: c63227b95a0c1bc774707f8f4e7836a126ac23a6
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 6cfec3a04de67aea335c23b5a3bd334a3a68fafe
+  revision: 5ac799cdcc5a7865b452daa96f92812144dccb3d
   specs:
-    omnibus (6.0.4)
+    omnibus (6.0.10)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,21 +30,21 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.107.0)
-    aws-sdk-core (3.36.0)
+    aws-partitions (1.125.0)
+    aws-sdk-core (3.44.1)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.11.0)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-kms (1.13.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.23.1)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-s3 (1.30.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
-    berkshelf (7.0.6)
+    berkshelf (7.0.7)
       chef (>= 13.6.52)
       chef-config
       cleanroom (~> 1.0)
@@ -58,10 +58,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.6.47)
+    chef (14.8.12)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.6.47)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -88,10 +88,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.6.47-universal-mingw32)
+    chef (14.8.12-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.6.47)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -120,6 +120,7 @@ GEM
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
+      win32-certstore (>= 0.1.8)
       win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
@@ -130,25 +131,25 @@ GEM
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.6.47)
+    chef-config (14.8.12)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-sugar (4.1.0)
-    chef-zero (14.0.6)
+    chef-sugar (4.2.1)
+    chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 2.0)
-      rack (~> 2.0)
+      rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
     citrus (3.0.2)
     cleanroom (1.0.0)
-    concurrent-ruby (1.1.0)
+    concurrent-ruby (1.1.4)
     diff-lcs (1.3)
     erubis (2.7.0)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     ffi (1.9.25-x64-mingw32)
@@ -173,7 +174,7 @@ GEM
     kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.16)
+    license_scout (1.0.19)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -182,21 +183,21 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     minitar (0.7)
-    mixlib-archive (0.4.18)
+    mixlib-archive (0.4.19)
       mixlib-log
-    mixlib-archive (0.4.18-universal-mingw32)
+    mixlib-archive (0.4.19-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.5)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.4)
-    mixlib-shellout (2.4.0)
-    mixlib-shellout (2.4.0-universal-mingw32)
+    mixlib-log (2.0.9)
+    mixlib-shellout (2.4.4)
+    mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.2)
@@ -217,7 +218,7 @@ GEM
     nori (2.6.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.6.2)
+    ohai (14.8.10)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -239,7 +240,7 @@ GEM
     progressbar (1.10.0)
     proxifier (1.0.3)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     retryable (2.0.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -266,17 +267,17 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    semverse (2.0.0)
+    semverse (3.0.0)
     serverspec (2.41.3)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    solve (4.0.0)
+    solve (4.0.2)
       molinillo (~> 0.6)
-      semverse (>= 1.1, < 3.0)
-    specinfra (2.76.3)
+      semverse (>= 1.1, < 4.0)
+    specinfra (2.76.5)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -284,7 +285,7 @@ GEM
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.23.2)
+    test-kitchen (1.23.5)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -294,12 +295,15 @@ GEM
       winrm (~> 2.0)
       winrm-elevated (~> 1.0)
       winrm-fs (~> 1.1)
-    thor (0.20.0)
+    thor (0.20.3)
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.7)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)
+    win32-certstore (0.1.11)
+      ffi
+      mixlib-shellout
     win32-dir (0.5.1)
       ffi (>= 1.0.0)
     win32-event (0.6.3)
@@ -317,7 +321,7 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (2.0.0)
+    win32-taskscheduler (2.0.1)
       ffi
       structured_warnings
     windows-api (0.4.4)
@@ -339,7 +343,7 @@ GEM
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    wmi-lite (1.0.0)
+    wmi-lite (1.0.1)
     zhexdump (0.0.2)
 
 PLATFORMS
@@ -356,4 +360,4 @@ DEPENDENCIES
   winrm-fs
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,13 +1,9 @@
 build_iteration 1
 
-# Using pins that agree with chef 13.0.118.
+# Using pins that agree with chef 13.11.3.
 override :chef,           version: "v13.11.3"
 override :ohai,           version: "v13.10.0"
 
-# Need modern bundler if we wish to support x-plat Gemfile.lock.
-# Unfortunately, 1.14.x series has issues with BUNDLER_VERSION variables exported by
-# the omnibus cookbook. Bump to it after the builders no longer set that environment
-# variable.
 override :bundler,        version: "1.15.4"
 override :rubygems,       version: "2.7.6"
 override :ruby,           version: "2.4.5"

--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PushyClient::VERSION
 
-  gem.required_ruby_version = '>= 2.2'
+  gem.required_ruby_version = '>= 2.3'
 
-  gem.add_dependency "chef", ">= 12.19", "< 15.0"
-  gem.add_dependency "ohai", ">= 8.23", "< 15.0"
+  gem.add_dependency "chef", ">= 13.0", "< 16.0"
+  gem.add_dependency "ohai", ">= 13.0", "< 16.0"
   gem.add_dependency "ffi-rzmq"
   gem.add_dependency "uuidtools"
 

--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PushyClient::VERSION
 
-  gem.required_ruby_version = '>= 2.3'
+  gem.required_ruby_version = '>= 2.4'
 
   gem.add_dependency "chef", ">= 13.0", "< 16.0"
   gem.add_dependency "ohai", ">= 13.0", "< 16.0"


### PR DESCRIPTION
Remove support for Chef 12 and Ruby 2.2/2.3.

Signed-off-by: Tim Smith <tsmith@chef.io>