### PR TITLE
Don't ship omnibus files in the gem artifact

### DIFF
--- a/opscode-pushy-client.gemspec
+++ b/opscode-pushy-client.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/chef/opscode-pushy-client"
 
   gem.executables   = Dir.glob('bin/**/*').map{|f| File.basename(f)}
-  gem.files         = Dir.glob('**/*').reject{|f| File.directory?(f)}
+  gem.files         = %w{opscode-pushy-client.gemspec Gemfile Rakefile LICENSE} + Dir.glob('{bin,lib,spec, keys}/**/*').reject{|f| File.directory?(f)}
   gem.test_files    = Dir.glob('{test,spec,features}/**/*')
   gem.name          = "opscode-pushy-client"
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Slim down the files we ship in the gem artifact to just what we need to build and test the client. This takes the gem artifact from 794 KB to 28k.

Signed-off-by: Tim Smith <tsmith@chef.io>