### PR TITLE
Expeditor should push omnibus packages through artifactory

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -35,4 +35,5 @@ merge_actions:
 promote:
   actions:
     - built_in:rollover_changelog
+    - built_in:promote_artifactory_artifact
     - built_in:notify_chefio_slack_channels


### PR DESCRIPTION
If there is no top level 'promote' key then expeditor will default to:
`- built_in:promote_artifactory_artifact`

But we have a promote key here and are lacking that action. This adds it.