### PR TITLE
Remove the unused windows-api gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ end
 platforms :mswin, :mingw do
   gem "ffi"
   gem "rdp-ruby-wmi"
-  gem "windows-api"
   gem "windows-pr"
   gem "win32-api"
   gem "win32-dir"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     iso8601 (0.12.1)
     json (2.2.0)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.5)
+    license-acceptance (1.0.8)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
@@ -307,7 +307,6 @@ DEPENDENCIES
   win32-open3
   win32-process (>= 0.8.2)
   win32-service
-  windows-api
   windows-pr
   yard
 


### PR DESCRIPTION
We don't need this in the omnibus packages since we don't actually use
it anywhere in our ecosystem.

Signed-off-by: Tim Smith <tsmith@chef.io>