### PR TITLE
Use new omnibus-toolchain scripts in omnibus-test.* scripts

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -10,22 +10,11 @@ If ([string]::IsNullOrEmpty($product)) { $product = "push-jobs-client" }
 $version = "$Env:VERSION"
 If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
 
-Write-Output "--- Downloading $channel $product $version"
-$download_url = C:\opscode\omnibus-toolchain\embedded\bin\mixlib-install.bat download --url --channel "$channel" "$product" --version "$version"
-$package_file = "$Env:Temp\$(Split-Path -Path $download_url -Leaf)"
-Invoke-WebRequest -OutFile "$package_file" -Uri "$download_url"
-
-Write-Output "--- Checking that $package_file has been signed."
-If ((Get-AuthenticodeSignature "$package_file").Status -eq 'Valid') {
-  Write-Output "Verified $package_file has been signed."
-}
-Else {
-  Write-Output "Exiting with an error because $package_file has not been signed. Check your omnibus project config."
-  exit 1
-}
-
 Write-Output "--- Installing $channel $product $version"
-Start-Process "$package_file" /quiet -Wait
+$package_file = $(C:\opscode\omnibus-toolchain\bin\install-omnibus-product.ps1 -Product "$product" -Channel "$channel" -Version "$version" | Select-Object -Last 1)
+
+Write-Output "--- Verifying omnibus package is signed"
+C:\opscode\omnibus-toolchain\bin\check-omnibus-package-signed.ps1 "$package_file"
 
 Write-Output "--- Running verification for $channel $product $version"
 $Env:PATH = "C:\opscode\push-jobs-client\bin;$Env:PATH"


### PR DESCRIPTION
### Description

This just updates the `omnibus-test.*` scripts to use tools that have been moved into the omnibus-toolchain. It also makes some changes to output to be more consistent across our omnibus projects.