### PR TITLE
Deprecate Ubuntu-14

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -19,10 +19,6 @@ builder-to-testers-map:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
-  ubuntu-14.04-i386:
-    - ubuntu-14.04-i386
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -27,7 +27,7 @@ Our current support platforms are as follows:
 
 - Debian 6, 7
 - Rhel 5, 6, 7
-- Ubuntu 10.04, 12.04, 14.04
+- Ubuntu 16.04, 18.04
 - Windows 7, 8, 8.1, 10, Server 2008 R2, 2012, 2012 R2
 
 Currently, push-client must be manually tested to verify that it behaves correctly on its supported platforms. You can use the [push-setup](https://github.com/chef/oc-pushy-pedant/tree/master/dev/push-setup) script to easily set up a push-jobs-client + push-jobs-server cluster with the desired build versions that you'd like to test.

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -45,17 +45,9 @@ platforms:
       - freebsd::pkgng
   - name: freebsd-10.0
     run_list: freebsd::portsnap
-  - name: ubuntu-10.04
+  - name: ubuntu-16.04
     run_list: apt::default
-  - name: ubuntu-12.04
-    run_list: apt::default
-  - name: ubuntu-12.10
-    run_list: apt::default
-  - name: ubuntu-13.04
-    run_list: apt::default
-  - name: ubuntu-13.10
-    run_list: apt::default
-  - name: ubuntu-14.04
+  - name: ubuntu-18.04
     run_list: apt::default
   # The following (private) boxes are shared via Atlas and are only
   # available to users working for Chef. Sorry, it's about software licensing.

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -84,14 +84,14 @@ liking, you can bring up an individual build environment using the `kitchen`
 command.
 
 ```shell
-$ kitchen converge push-jobs-client-ubuntu-1204
+$ kitchen converge push-jobs-client-ubuntu-1604
 ```
 
 Then login to the instance and build the project as described in the Usage
 section:
 
 ```shell
-$ kitchen login push-jobs-client-ubuntu-1204
+$ kitchen login push-jobs-client-ubuntu-1604
 [vagrant@ubuntu...] $ cd opscode-pushy-client/omnibus
 [vagrant@ubuntu...] $ source ~/load-omnibus-toolchain.sh
 [vagrant@ubuntu...] $ bundle install --without development # Don't install dev tools!

--- a/omnibus/acceptance/.kitchen.yml
+++ b/omnibus/acceptance/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
       log_level: ":debug"
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-16.04
     run_list:
       - recipe[apt::default]
   - name: windows-2012r2

--- a/omnibus/acceptance/Makefile
+++ b/omnibus/acceptance/Makefile
@@ -1,12 +1,12 @@
 
 chef-server:
-	kitchen converge chef-server-ubuntu-1404
+	kitchen converge chef-server-ubuntu-1604
 
 windows-client:
 	kitchen converge push-jobs-client-windows-2012r2
 
 ubuntu-client:
-	kitchen converge push-jobs-client-ubuntu-1404
+	kitchen converge push-jobs-client-ubuntu-1604
 
 clean:
 	find .chef/$* ! -name 'knife.rb' -type f -exec rm -f {} +


### PR DESCRIPTION
Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Description

Deprecate Ubuntu-14

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
