### PR TITLE
Enable RHEL8 Windows 2016 and Windows 2019 packages

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -15,6 +15,7 @@ builder-to-testers-map:
     - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
+    - el-8-x86_64
   mac_os_x-10.12-x86_64:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
@@ -27,3 +28,5 @@ builder-to-testers-map:
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64
+    - windows-2016-x86_64
+    - windows-2019-x86_64


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Enable RHEL8, Windows 2016 and Windows 2019 packages

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
