### PR TITLE
[ci] Fix omnibus pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,8 +9,8 @@ builder-to-testers-map:
   debian-8-x86_64:
     - debian-8-x86_64
     - debian-9-x86_64
-  el-6-i386:
-    - el-6-i386
+  el-6-i686:
+    - el-6-i686
   el-6-x86_64:
     - el-6-x86_64
   el-7-x86_64:

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'omnibus', git: 'https://github.com/chef/omnibus.git'
 gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git'
+gem 'artifactory'
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 035cc8392be8906b4c13e7dd2048d9c659fd034e
+  revision: 33bddeefb10afe23a57ea72807625881ab01990f
   specs:
-    omnibus (6.0.30)
+    omnibus (6.1.0)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -28,19 +28,20 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.174.0)
-    aws-sdk-core (3.54.2)
+    aws-partitions (1.196.0)
+    aws-sdk-core (3.62.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.21.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.42.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-s3 (1.46.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
@@ -231,7 +232,7 @@ GEM
     nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (15.0.35)
+    ohai (15.1.5)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -255,7 +256,7 @@ GEM
     plist (3.5.0)
     progressbar (1.10.1)
     proxifier (1.0.3)
-    public_suffix (3.1.0)
+    public_suffix (3.1.1)
     rack (2.0.7)
     retryable (3.0.4)
     ruby-progressbar (1.10.1)
@@ -369,6 +370,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  artifactory
   berkshelf
   kitchen-vagrant
   omnibus!


### PR DESCRIPTION
## Description

This change only affects CI. A new version of omnibus is required and the artifactory gem is required for the publish part of the build stage. Platform names in `release.omnibus.yml` are also fixed to conform with what the new package publishing code in the omnibus gem expects.

## Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22