### PR TITLE
Update Gemfile.lock and remove libsodium pinning

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 5f57d0a9243cc4c476d2acafc9aaafd61ceb1b03
+  revision: 348b519dac442f3caa1560896fb6264a37907d09
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.6.1)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: fb089c39c178da353d1d89a1f4bd79b6cbb78b77
+  revision: 3eae1cd2e5b9bb62775485e1dfa59aec8c70f5da
   specs:
-    omnibus (7.0.9)
+    omnibus (7.0.20)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)
@@ -17,7 +17,7 @@ GIT
       license_scout (~> 1.0)
       mixlib-shellout (>= 2.0, < 4.0)
       mixlib-versioning
-      ohai (>= 13, < 16)
+      ohai (>= 13, < 17)
       pedump
       ruby-progressbar (~> 1.7)
       thor (>= 0.18, < 2.0)
@@ -30,21 +30,21 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.305.0)
-    aws-sdk-core (3.94.0)
+    aws-partitions (1.354.0)
+    aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.30.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.63.0)
-      aws-sdk-core (~> 3, >= 3.83.0)
+    aws-sdk-s3 (1.78.0)
+      aws-sdk-core (~> 3, >= 3.104.3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.3)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sigv4 (1.2.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt_pbkdf (1.0.1)
     bcrypt_pbkdf (1.0.1-x64-mingw32)
     bcrypt_pbkdf (1.0.1-x86-mingw32)
@@ -164,9 +164,9 @@ GEM
     erubis (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.2)
-    ffi (1.12.2-x64-mingw32)
-    ffi (1.12.2-x86-mingw32)
+    ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
+    ffi (1.13.1-x86-mingw32)
     ffi-libarchive (1.0.0)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.3)
@@ -195,7 +195,7 @@ GEM
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
       tty-prompt (~> 0.18)
-    license_scout (1.1.8)
+    license_scout (1.1.9)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)
@@ -217,8 +217,10 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.8)
-    mixlib-shellout (3.0.9)
-    mixlib-shellout (3.0.9-universal-mingw32)
+    mixlib-shellout (3.1.2)
+      chef-utils
+    mixlib-shellout (3.1.2-universal-mingw32)
+      chef-utils
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
@@ -240,7 +242,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (15.9.1)
+    ohai (15.12.0)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -255,17 +257,15 @@ GEM
     pastel (0.7.3)
       equatable (~> 0.6)
       tty-color (~> 0.5)
-    pedump (0.5.4)
+    pedump (0.6.1)
       awesome_print
       iostruct (>= 0.0.4)
       multipart-post (>= 2.0.0)
-      progressbar
       rainbow
       zhexdump (>= 0.0.2)
     plist (3.5.0)
-    progressbar (1.10.1)
     proxifier (1.0.3)
-    public_suffix (4.0.4)
+    public_suffix (4.0.5)
     rack (2.2.2)
     rainbow (3.0.0)
     retryable (3.0.5)
@@ -392,4 +392,4 @@ DEPENDENCIES
   winrm-fs
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -6,7 +6,6 @@ override :ohai,           version: "v15.9.1"
 override :ruby,           version: "2.6.6"
 
 override :libxml2,        version: "2.9.10"
-override :libsodium,      version: "1.0.12"
 
 if aix?
   # To get LibZMQ building on AIX we needed to update to 4.2.2 because it has autotools and


### PR DESCRIPTION
### Description

Update Gemfile.lock and remove libsodium pinning

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
